### PR TITLE
Change Proposal 2022 for CH-ATC

### DIFF
--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -87,6 +87,14 @@
     </resource>
     <resource>
       <reference>
+        <reference value="StructureDefinition/HpdAuditEvent" />
+      </reference>
+      <name value="Profile on HpdAuditEvent for CH ATC" />
+      <description value="Profile on HpdAuditEvent for CH ATC" />
+      <exampleBoolean value="false"/>
+    </resource>
+    <resource>
+      <reference>
         <reference value="StructureDefinition/CH-ATC.ITI-81.Response" />
       </reference>
       <name value="Retrieve CH ATC ATNA Audit Event [ITI-81] Response" />
@@ -123,6 +131,14 @@
       </reference>
       <name value="AccessAuditTrailEventType" />
       <description value="AccessAuditTrailEventType" />
+      <exampleBoolean value="false" />
+    </resource>
+    <resource>
+      <reference>
+        <reference value="ValueSet/HpdAuditEventType" />
+      </reference>
+      <name value="HpdAuditEventType" />
+      <description value="HpdAuditEventType" />
       <exampleBoolean value="false" />
     </resource>
     <resource>
@@ -164,6 +180,22 @@
       <name value="CH ATC - Access of Audit Trail Repository" />
       <description value="CH ATC - Access of Audit Trail Repository" />
       <exampleCanonical value="http://fhir.ch/ig/ch-atc/StructureDefinition/AccessAuditTrailEvent" />
+    </resource>
+    <resource>
+      <reference>
+        <reference value="AuditEvent/atc-doc-meta-query" />
+      </reference>
+      <name value="CH ATC - Audit Event for Document Metadata query" />
+      <description value="CH ATC - Audit Event for Document Metadata query" />
+      <exampleCanonical value="http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent" />
+    </resource>
+    <resource>
+      <reference>
+        <reference value="AuditEvent/atc-hpd-group-entry-notify" />
+      </reference>
+      <name value="CH ATC - Audit Event for Group Entry Audit Event Content Profile" />
+      <description value="AuditEvent of Healthcare professional which has been added to a group and patient has been notified" />
+      <exampleCanonical value="http://fhir.ch/ig/ch-atc/StructureDefinition/HpdAuditEvent" />
     </resource>
     <resource>
       <reference>

--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -33,7 +33,7 @@
       <value value="oliver.egger@ahdis.ch"/>
     </telecom>
   </contact>
-  <description value="Implementation Guide for CH ATC see Audit Trail Consumption" />
+  <description value="Implementation Guide for CH ATC (Audit Trail Consumption)" />
   <jurisdiction>
     <coding>
       <system value="urn:iso:std:iso:3166"/>

--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -226,6 +226,11 @@
         <title value="Terminology"/>
         <generation value="html"/>
       </page>
+      <page>
+        <nameUrl value="changelog.html"/>
+        <title value="Change Log"/>
+        <generation value="markdown"/>
+      </page>
     </page>
     <parameter>
       <code value="generate-json"/>

--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -58,7 +58,7 @@
         <reference value="SearchParameter/AuditEvent-entity-identifier" />
       </reference>
       <name value="Search Parameter AuditEvent entity.identifier" />
-      <description value="Defines the IHE RESTFul ATNA Query Parameter entity.identifier for an AuditEvent" />
+      <description value="Defines the IHE RESTFul ATNA Query Parameter entity.identifier for an AuditEvent." />
       <exampleBoolean value="false" />
     </resource>
     <resource>
@@ -66,7 +66,7 @@
         <reference value="StructureDefinition/DocumentAuditEvent" />
       </reference>
       <name value="Profile on DocumentAuditEvent for CH ATC" />
-      <description value="Profile on DocumentAuditEvent for CH ATC" />
+      <description value="This profile defines the content of the document audit events which a community has to provide for a patients audit trail." />
       <exampleBoolean value="false" />
     </resource>
     <resource>
@@ -74,7 +74,7 @@
         <reference value="StructureDefinition/PolicyAuditEvent" />
       </reference>
       <name value="Profile on PolicyAuditEvent for CH ATC" />
-      <description value="Profile on PolicyAuditEvent for CH ATC" />
+      <description value="This profile defines the content of the policy audit events which a community has to provide for a patients audit trail." />
       <exampleBoolean value="false"/>
     </resource>
     <resource>
@@ -82,7 +82,7 @@
         <reference value="StructureDefinition/AccessAuditTrailEvent" />
       </reference>
       <name value="Profile on AccessAuditTrailEvent for CH ATC" />
-      <description value="Profile on AccessAuditTrailEvent for CH ATC" />
+      <description value="This profile defines the content of the access audit trail event which a community has to provide for a patients audit trail." />
       <exampleBoolean value="false"/>
     </resource>
     <resource>
@@ -90,7 +90,7 @@
         <reference value="StructureDefinition/HpdAuditEvent" />
       </reference>
       <name value="Profile on HpdAuditEvent for CH ATC" />
-      <description value="Profile on HpdAuditEvent for CH ATC" />
+      <description value="This profile defines the content of the HPD audit events which a community has to provide for a patients audit trail." />
       <exampleBoolean value="false"/>
     </resource>
     <resource>
@@ -98,15 +98,15 @@
         <reference value="StructureDefinition/CH-ATC.ITI-81.Response" />
       </reference>
       <name value="Retrieve CH ATC ATNA Audit Event [ITI-81] Response" />
-      <description value="Retrieve CH ATC ATNA Audit Event [ITI-81] Response" />
+      <description value="Implementation Guide for CH ATC see Audit Trail Consumption" />
       <exampleBoolean value="false" />
     </resource>
     <resource>
       <reference>
         <reference value="ValueSet/EprParticipant" />
       </reference>
-      <name value="EPR Participant" />
-      <description value="EPR Participant" />
+      <name value="EprParticipant" />
+      <description value="EprParticipant" />
       <exampleBoolean value="false"/>
     </resource>
     <resource>
@@ -154,7 +154,7 @@
         <reference value="AuditEvent/atc-doc-read-ass-hpc" />
       </reference>
       <name value="CH ATC - Retrieveal of a Document" />
-      <description value="CH ATC - Retrieveal of a Document from a patient by an assitant for a healthcrare professional" />
+      <description value="CH ATC - Retrieveal of a Document from a patient by an assitant for a healthcare professional" />
       <exampleCanonical value="http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent" />
     </resource>
     <resource>
@@ -194,7 +194,7 @@
         <reference value="AuditEvent/atc-hpd-group-entry-notify" />
       </reference>
       <name value="CH ATC - Audit Event for Group Entry Audit Event Content Profile" />
-      <description value="AuditEvent of Healthcare professional which has been added to a group and patient has been notified" />
+      <description value="CH ATC - AuditEvent of Healthcare professional which has been added to a group and patient has been notified" />
       <exampleCanonical value="http://fhir.ch/ig/ch-atc/StructureDefinition/HpdAuditEvent" />
     </resource>
     <resource>

--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -183,10 +183,10 @@
     </resource>
     <resource>
       <reference>
-        <reference value="AuditEvent/atc-doc-meta-query" />
+        <reference value="AuditEvent/atc-doc-search" />
       </reference>
-      <name value="CH ATC - Audit Event for Document Metadata query" />
-      <description value="CH ATC - Audit Event for Document Metadata query" />
+      <name value="CH ATC - Audit Event for Document Search" />
+      <description value="CH ATC - Audit Event for Document Search" />
       <exampleCanonical value="http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent" />
     </resource>
     <resource>

--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -98,7 +98,7 @@
         <reference value="StructureDefinition/CH-ATC.ITI-81.Response" />
       </reference>
       <name value="Retrieve CH ATC ATNA Audit Event [ITI-81] Response" />
-      <description value="Implementation Guide for CH ATC see Audit Trail Consumption" />
+      <description value="This profile defines the response to the [ITI-81] query. The response is a search set including all audit events which a community has to provide for a patients audit trail." />
       <exampleBoolean value="false" />
     </resource>
     <resource>

--- a/input/examples/auditevent/atc-doc-create-rep-pat.xml
+++ b/input/examples/auditevent/atc-doc-create-rep-pat.xml
@@ -5,7 +5,7 @@
    </meta>
    <text>
       <status value="generated"></status>
-      <div xmlns="http://www.w3.org/1999/xhtml">Upload of Birth certificate  10.10.2020 18:29 from Julia Helfe-Gern on behalf of Jakob Wieder-Gesund </div>
+      <div xmlns="http://www.w3.org/1999/xhtml">Upload of Record artifcat  10.10.2020 18:29 from Julia Helfe-Gern on behalf of Jakob Wieder-Gesund </div>
    </text>
    <type>
       <system value="http://dicom.nema.org/resources/ontology/DCM"></system>
@@ -119,8 +119,8 @@
       </detail>
       <detail>
          <type value="EprDocumentTypeCode"></type>
-         <valueBase64Binary value="NDQ0NTYxMDAx"></valueBase64Binary>
-                     <!-- base64 typeCode 444561001 -->
+         <valueBase64Binary value="NDE5ODkxMDA4"></valueBase64Binary>
+                     <!-- base64 typeCode 419891008 -->
       </detail>
    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-doc-create-rep-pat.xml
+++ b/input/examples/auditevent/atc-doc-create-rep-pat.xml
@@ -122,5 +122,10 @@
          <valueBase64Binary value="NDE5ODkxMDA4"></valueBase64Binary>
                      <!-- base64 typeCode 419891008 -->
       </detail>
+      <detail>
+         <type value="title"></type>
+         <valueBase64Binary value="QXVzdHJpdHRzYmVyaWNodCB2b24gSnVsaWEgSGVsZmUtR2Vybg=="></valueBase64Binary>
+         <!-- base64 title Austrittsbericht von Julia Helfe-Gern  -->
+      </detail>
    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-doc-meta-query.xml
+++ b/input/examples/auditevent/atc-doc-meta-query.xml
@@ -5,7 +5,7 @@
     </meta>
     <text>
         <status value="generated"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">Search for documents 10.10.2022 18:49 Dr. med. Sabine Musterfrau requesting documents in Emergency Access from  Kardiologie Universitätsspital Musterstadt 
+        <div xmlns="http://www.w3.org/1999/xhtml">Search for documents 10.10.2022 18:49 Dr. med. Sabine Musterfrau requesting documents in Emergency Access from Kardiologie Universitätsspital Musterstadt 
         </div>
     </text>
     <type>
@@ -15,8 +15,8 @@
     </type>
     <subtype>
         <system value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
-        <code value="ATC_DOC_META_QUERY"/>
-        <display value="Document Metadata query"/>
+        <code value="ATC_DOC_SEARCH"/>
+        <display value="Document or Document Metadata query"/>
     </subtype>
     <action value="C"/>
     <recorded value="2022-10-10T18:49:00Z"/>

--- a/input/examples/auditevent/atc-doc-meta-query.xml
+++ b/input/examples/auditevent/atc-doc-meta-query.xml
@@ -1,0 +1,104 @@
+<AuditEvent xmlns="http://hl7.org/fhir">
+    <id value="atc-doc-meta-query"/>
+    <meta>
+        <profile value="http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent" />
+    </meta>
+    <text>
+        <status value="generated"/>
+        <div xmlns="http://www.w3.org/1999/xhtml"> Search for documents 10.10.2022 18:49 Dr. med. Sabine Musterfrau requesting docuemnts in Emergency Access from  Kardiologie Universitätsspital Musterstadt 
+        </div>
+    </text>
+    <type>
+        <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+        <code value="110106"/>
+        <display value="Export"/>
+    </type>
+    <subtype>
+        <system value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
+        <code value="ATC_DOC_META_QUERY"/>
+        <display value="Document Metadata query"/>
+    </subtype>
+    <action value="C"/>
+    <recorded value="2022-10-10T18:49:00Z"/>
+    <outcome value="0"/>
+    <purposeOfEvent>
+        <coding>
+            <system value="urn:oid:2.16.756.5.30.1.127.3.10.5"/>
+            <code value="EMER"/>
+            <display value="Emergency Access"/>
+        </coding>
+    </purposeOfEvent>
+    <agent>
+        <role>
+            <coding>
+                <system value="urn:oid:2.16.756.5.30.1.127.3.10.6"/>
+                <code value="HCP"/>
+                <display value="Healthcare professional"/>
+            </coding>
+        </role>
+        <name value="Dr. med. Sabine Musterfrau" />
+        <requestor value="true" />
+    </agent>
+    <agent>
+        <role>
+            <coding>
+                <system value="urn:oid:2.16.756.5.30.1.127.3.10.14"/>
+                <code value="GRP"/>
+                <display value="Group"/>
+            </coding>
+        </role>
+        <who>
+            <identifier>
+                <value value="urn:oid:1.1.1.1.1"/>
+            </identifier>
+        </who>
+        <name value="Kardiologie Universitätsspital Musterstadt"/>
+        <requestor value="false"/>
+    </agent>
+    <source>
+        <observer>
+            <identifier>
+                <system value="urn:ietf:rfc:3986"></system>
+                <value value="urn:oid:7.8.9.10.11"></value>
+            </identifier>
+        </observer>
+    </source>
+    <entity>
+        <!-- Patient -->
+        <what>
+            <identifier>
+                <system value="urn:oid:2.16.756.5.30.1.127.3.10.3" />
+                <value value="761337610469261945" />
+            </identifier>
+        </what>
+        <type>
+            <system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="1"/>
+            <display value="Person"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="1"/>
+            <display value="Patient"/>
+        </role>
+    </entity>
+    <entity>
+        <!-- Query -->
+        <what>
+            <identifier>
+                <system value="urn:ietf:rfc:3986" />
+                <value value="urn:uuid:4f86d34b-6f87-4fd6-8652-316a5704bc36" />
+            </identifier>
+        </what>
+        <type>
+            <system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="2"/>
+            <display value="System Object"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="24"/>
+            <display value="Query"/>
+        </role>
+    </entity>
+</AuditEvent>

--- a/input/examples/auditevent/atc-doc-meta-query.xml
+++ b/input/examples/auditevent/atc-doc-meta-query.xml
@@ -58,8 +58,8 @@
     <source>
         <observer>
             <identifier>
-                <system value="urn:ietf:rfc:3986"></system>
-                <value value="urn:oid:7.8.9.10.11"></value>
+                <system value="urn:ietf:rfc:3986"/>
+                <value value="urn:oid:7.8.9.10.11"/>
             </identifier>
         </observer>
     </source>

--- a/input/examples/auditevent/atc-doc-meta-query.xml
+++ b/input/examples/auditevent/atc-doc-meta-query.xml
@@ -18,7 +18,7 @@
         <code value="ATC_DOC_SEARCH"/>
         <display value="Document or Document Metadata query"/>
     </subtype>
-    <action value="C"/>
+    <action value="E"/>
     <recorded value="2022-10-10T18:49:00Z"/>
     <outcome value="0"/>
     <purposeOfEvent>

--- a/input/examples/auditevent/atc-doc-meta-query.xml
+++ b/input/examples/auditevent/atc-doc-meta-query.xml
@@ -5,7 +5,7 @@
     </meta>
     <text>
         <status value="generated"/>
-        <div xmlns="http://www.w3.org/1999/xhtml"> Search for documents 10.10.2022 18:49 Dr. med. Sabine Musterfrau requesting docuemnts in Emergency Access from  Kardiologie Universitätsspital Musterstadt 
+        <div xmlns="http://www.w3.org/1999/xhtml">Search for documents 10.10.2022 18:49 Dr. med. Sabine Musterfrau requesting documents in Emergency Access from  Kardiologie Universitätsspital Musterstadt 
         </div>
     </text>
     <type>

--- a/input/examples/auditevent/atc-doc-read-ass-hpc.xml
+++ b/input/examples/auditevent/atc-doc-read-ass-hpc.xml
@@ -5,7 +5,7 @@
    </meta>
    <text>
       <status value="generated"></status>
-      <div xmlns="http://www.w3.org/1999/xhtml">Document retrieval of radiology report from Regula Fischer 20.10.2020 14:29          on behalf of Dr. med. Hans Allzeitbereit, Member of group Labor 1 Bertaspital, Emergency Access </div>
+      <div xmlns="http://www.w3.org/1999/xhtml">Document retrieval of record artifact from Regula Fischer 20.10.2020 14:29          on behalf of Dr. med. Hans Allzeitbereit, Member of group Labor 1 Bertaspital, Emergency Access </div>
    </text>
    <type>
       <system value="http://dicom.nema.org/resources/ontology/DCM"></system>
@@ -136,8 +136,8 @@
       </detail>
       <detail>
          <type value="EprDocumentTypeCode"></type>
-         <valueBase64Binary value="NDQ0NTYxMDAx"></valueBase64Binary>
-         <!-- base64 typeCode 444561001 -->
+         <valueBase64Binary value="NDE5ODkxMDA4"></valueBase64Binary>
+         <!-- base64 typeCode 419891008 -->
       </detail>
    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-doc-read-ass-hpc.xml
+++ b/input/examples/auditevent/atc-doc-read-ass-hpc.xml
@@ -139,5 +139,10 @@
          <valueBase64Binary value="NDE5ODkxMDA4"></valueBase64Binary>
          <!-- base64 typeCode 419891008 -->
       </detail>
+      <detail>
+         <type value="title"></type>
+         <valueBase64Binary value="QXVzdHJpdHRzYmVyaWNodA=="></valueBase64Binary>
+         <!-- base64 title Austrittsbericht  -->
+      </detail>
    </entity>
 </AuditEvent>

--- a/input/examples/auditevent/atc-doc-search.xml
+++ b/input/examples/auditevent/atc-doc-search.xml
@@ -87,7 +87,8 @@
         <what>
             <identifier>
                 <system value="urn:ietf:rfc:3986" />
-                <value value="urn:uuid:4f86d34b-6f87-4fd6-8652-316a5704bc36" />
+                <value value="urn:uuid:14d4debf-8f97-4251-9a74-a90016b0af0d" />
+                <!-- Stored Query Id: https://profiles.ihe.net/ITI/TF/Volume2/ITI-18.html#3.18.4.1.2.4 -->
             </identifier>
         </what>
         <type>

--- a/input/examples/auditevent/atc-doc-search.xml
+++ b/input/examples/auditevent/atc-doc-search.xml
@@ -1,5 +1,5 @@
 <AuditEvent xmlns="http://hl7.org/fhir">
-    <id value="atc-doc-meta-query"/>
+    <id value="atc-doc-search"/>
     <meta>
         <profile value="http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent" />
     </meta>
@@ -16,7 +16,7 @@
     <subtype>
         <system value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
         <code value="ATC_DOC_SEARCH"/>
-        <display value="Document or Document Metadata query"/>
+        <display value="Document search"/>
     </subtype>
     <action value="E"/>
     <recorded value="2022-10-10T18:49:00Z"/>

--- a/input/examples/auditevent/atc-hpd-group-entry-notify.xml
+++ b/input/examples/auditevent/atc-hpd-group-entry-notify.xml
@@ -65,8 +65,8 @@
         </what>
         <type>
             <system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
-            <code value="2"/>
-            <display value="System Object"/>
+            <code value="1"/>
+            <display value="Person"/>
         </type>
         <role>
             <system value="urn:oid:2.16.756.5.30.1.127.3.10.6"/>

--- a/input/examples/auditevent/atc-hpd-group-entry-notify.xml
+++ b/input/examples/auditevent/atc-hpd-group-entry-notify.xml
@@ -26,11 +26,11 @@
         <role>
             <coding>
                 <system value="urn:oid:2.16.756.5.30.1.127.3.10.6"/>
-                <code value="HCP"/>
-                <display value="Healthcare professional"/>
+                <code value="PADM"/>
+                <display value="Policy Administrator"/>
             </coding>
         </role>
-        <name value="Dr. med. Sabine Musterfrau" />
+        <name value="Notifikations-Dienst" />
         <requestor value="false" />
     </agent>
     <source>
@@ -41,6 +41,7 @@
             </identifier>
         </observer>
     </source>
+
     <entity>
         <!-- Patient -->
         <what>
@@ -60,8 +61,30 @@
             <display value="Patient"/>
         </role>
     </entity>
+
     <entity>
-        <!-- Group Entry -->
+        <!-- Healthcare professional  -->
+        <what>
+            <identifier>
+                <system value="urn:oid:2.51.1.3"/>
+                <value value="7601000050717"/>
+            </identifier>
+        </what>
+        <type>
+            <system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="2"/>
+            <display value="System Object"/>
+        </type>
+        <role>
+            <system value="urn:oid:2.16.756.5.30.1.127.3.10.6"/>
+            <code value="HCP"/>
+            <display value="Healthcare professional"/>
+        </role>
+        <name value="Dr. med. Sabine Musterfrau"/>
+    </entity>
+
+    <entity>
+        <!-- Group -->
         <what>
             <identifier>
                 <value value="urn:oid:1.1.1.1.1"/>
@@ -70,12 +93,14 @@
         <type>
             <system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
             <code value="3"/>
+            <display value="Organization"/>
         </type>
         <role>
-            <system value="urn:oid:2.16.756.5.30.1.127.3.10.14"></system>
-            <code value="GRP"></code>
+            <system value="urn:oid:2.16.756.5.30.1.127.3.10.14"/>
+            <code value="GRP"/>
+            <display value="Group"/>
         </role>
-        <name value="Kardiologie Universitätsspital Musterstadt"></name>
+        <name value="Kardiologie Universitätsspital Musterstadt"/>
     </entity>
 </AuditEvent>
 

--- a/input/examples/auditevent/atc-hpd-group-entry-notify.xml
+++ b/input/examples/auditevent/atc-hpd-group-entry-notify.xml
@@ -36,8 +36,8 @@
     <source>
         <observer>
             <identifier>
-                <system value="urn:ietf:rfc:3986"></system>
-                <value value="urn:oid:7.8.9.10.11"></value>
+                <system value="urn:ietf:rfc:3986"/>
+                <value value="urn:oid:7.8.9.10.11"/>
             </identifier>
         </observer>
     </source>

--- a/input/examples/auditevent/atc-hpd-group-entry-notify.xml
+++ b/input/examples/auditevent/atc-hpd-group-entry-notify.xml
@@ -1,0 +1,81 @@
+<AuditEvent xmlns="http://hl7.org/fhir">
+    <id value="atc-hpd-group-entry-notify"/>
+    <meta>
+        <profile value="http://fhir.ch/ig/ch-atc/StructureDefinition/HpdAuditEvent" />
+    </meta>
+    <text>
+        <status value="generated"/>
+        <div xmlns="http://www.w3.org/1999/xhtml">
+             10.10.2020 10:05: Healthcare professional Dr. med. Sabine Musterfrau has been added to Group Kardiologie Universitätsspital Musterstadt and patient Jakob Wieder-Gesund has been notified
+        </div>
+    </text>
+    <type>
+        <system value="http://dicom.nema.org/resources/ontology/DCM"/>
+        <code value="110106"/>
+        <display value="Export"/>
+    </type>
+    <subtype>
+        <system value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
+        <code value="ATC_HPD_GROUP_ENTRY_NOTIFY"/>
+        <display value="HPD Group Entry Notification"/>
+    </subtype>
+    <action value="C"/>
+    <recorded value="2022-10-10T10:05:00Z"/>
+    <outcome value="0"/>
+    <agent>
+        <role>
+            <coding>
+                <system value="urn:oid:2.16.756.5.30.1.127.3.10.6"/>
+                <code value="HCP"/>
+                <display value="Healthcare professional"/>
+            </coding>
+        </role>
+        <name value="Dr. med. Sabine Musterfrau" />
+        <requestor value="false" />
+    </agent>
+    <source>
+        <observer>
+            <identifier>
+                <system value="urn:ietf:rfc:3986"></system>
+                <value value="urn:oid:7.8.9.10.11"></value>
+            </identifier>
+        </observer>
+    </source>
+    <entity>
+        <!-- Patient -->
+        <what>
+            <identifier>
+                <system value="urn:oid:2.16.756.5.30.1.127.3.10.3" />
+                <value value="761337610469261945" />
+            </identifier>
+        </what>
+        <type>
+            <system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="1"/>
+            <display value="Person"/>
+        </type>
+        <role>
+            <system value="http://terminology.hl7.org/CodeSystem/object-role"/>
+            <code value="1"/>
+            <display value="Patient"/>
+        </role>
+    </entity>
+    <entity>
+        <!-- Group Entry -->
+        <what>
+            <identifier>
+                <value value="urn:oid:1.1.1.1.1"/>
+            </identifier>
+        </what>
+        <type>
+            <system value="http://terminology.hl7.org/CodeSystem/audit-entity-type"/>
+            <code value="3"/>
+        </type>
+        <role>
+            <system value="urn:oid:2.16.756.5.30.1.127.3.10.14"></system>
+            <code value="GRP"></code>
+        </role>
+        <name value="Kardiologie Universitätsspital Musterstadt"></name>
+    </entity>
+</AuditEvent>
+

--- a/input/examples/auditevent/atc-hpd-group-entry-notify.xml
+++ b/input/examples/auditevent/atc-hpd-group-entry-notify.xml
@@ -23,13 +23,6 @@
     <recorded value="2022-10-10T10:05:00Z"/>
     <outcome value="0"/>
     <agent>
-        <role>
-            <coding>
-                <system value="urn:oid:2.16.756.5.30.1.127.3.10.6"/>
-                <code value="PADM"/>
-                <display value="Policy Administrator"/>
-            </coding>
-        </role>
         <name value="Notifikations-Dienst" />
         <requestor value="false" />
     </agent>

--- a/input/examples/bundle/ch-atc-iti-81-response-sample.xml
+++ b/input/examples/bundle/ch-atc-iti-81-response-sample.xml
@@ -27,7 +27,7 @@
         <text>
           <status value="generated"/>
           <div 
-            xmlns="http://www.w3.org/1999/xhtml">Upload of Birth certificate  10.10.2020 18:29 from Julia Helfe-Gern on behalf of Jakob Wieder-Gesund 
+            xmlns="http://www.w3.org/1999/xhtml">Upload of Record artifact  10.10.2020 18:29 from Julia Helfe-Gern on behalf of Jakob Wieder-Gesund 
           </div>
         </text>
         <type>
@@ -142,8 +142,8 @@
           </detail>
           <detail>
             <type value="EprDocumentTypeCode"/>
-            <!-- base64 typeCode 444561001 -->
-            <valueBase64Binary value="NDQ0NTYxMDAx"/>
+            <!-- base64 typeCode 419891008 -->
+            <valueBase64Binary value="NDE5ODkxMDA4"/>
           </detail>
         </entity>
       </AuditEvent>

--- a/input/examples/bundle/ch-atc-iti-81-response-sample.xml
+++ b/input/examples/bundle/ch-atc-iti-81-response-sample.xml
@@ -143,8 +143,8 @@
             <valueBase64Binary value="NDE5ODkxMDA4"/>
           </detail>
           <detail>
-            <type value="title"></type>
-            <valueBase64Binary value="QXVzdHJpdHRzYmVyaWNodCB2b24gSnVsaWEgSGVsZmUtR2Vybg=="></valueBase64Binary>
+            <type value="title"/>
+            <valueBase64Binary value="QXVzdHJpdHRzYmVyaWNodCB2b24gSnVsaWEgSGVsZmUtR2Vybg=="/>
             <!-- base64 title Austrittsbericht von Julia Helfe-Gern  -->
           </detail>
         </entity>

--- a/input/examples/bundle/ch-atc-iti-81-response-sample.xml
+++ b/input/examples/bundle/ch-atc-iti-81-response-sample.xml
@@ -1,5 +1,4 @@
-<Bundle 
-  xmlns="http://hl7.org/fhir">
+<Bundle xmlns="http://hl7.org/fhir">
   <!--<id value="56562bcf-2a5a-48d4-9a83-0f0dbbef74cc"/>-->
   <id value="ch-atc-iti-81-response-sample"/>
   <meta>
@@ -15,8 +14,7 @@
   <entry>
     <fullUrl value="/r4/*/AuditEvent/1"/>
     <resource>
-      <AuditEvent 
-        xmlns="http://hl7.org/fhir">
+      <AuditEvent xmlns="http://hl7.org/fhir">
         <id value="1"/>
         <meta>
           <versionId value="1"/>
@@ -26,8 +24,7 @@
         </meta>
         <text>
           <status value="generated"/>
-          <div 
-            xmlns="http://www.w3.org/1999/xhtml">Upload of Record artifact  10.10.2020 18:29 from Julia Helfe-Gern on behalf of Jakob Wieder-Gesund 
+          <div xmlns="http://www.w3.org/1999/xhtml">Upload of Record artifact  10.10.2020 18:29 from Julia Helfe-Gern on behalf of Jakob Wieder-Gesund 
           </div>
         </text>
         <type>
@@ -145,6 +142,11 @@
             <!-- base64 typeCode 419891008 -->
             <valueBase64Binary value="NDE5ODkxMDA4"/>
           </detail>
+          <detail>
+            <type value="title"></type>
+            <valueBase64Binary value="QXVzdHJpdHRzYmVyaWNodCB2b24gSnVsaWEgSGVsZmUtR2Vybg=="></valueBase64Binary>
+            <!-- base64 title Austrittsbericht von Julia Helfe-Gern  -->
+          </detail>
         </entity>
       </AuditEvent>
     </resource>
@@ -155,8 +157,7 @@
   <entry>
     <fullUrl value="/r4/*/AuditEvent/2"/>
     <resource>
-      <AuditEvent 
-        xmlns="http://hl7.org/fhir">
+      <AuditEvent xmlns="http://hl7.org/fhir">
         <id value="2"/>
         <meta>
           <versionId value="1"/>
@@ -166,8 +167,7 @@
         </meta>
         <text>
           <status value="generated"/>
-          <div 
-            xmlns="http://www.w3.org/1999/xhtml">Jakob Wieder-Gesund has viewed the audit trail 22.09.2020 10:47 
+          <div xmlns="http://www.w3.org/1999/xhtml">Jakob Wieder-Gesund has viewed the audit trail 22.09.2020 10:47 
           </div>
         </text>
         <type>
@@ -231,8 +231,7 @@
   <entry>
     <fullUrl value="/r4/*/AuditEvent/3"/>
     <resource>
-      <AuditEvent 
-        xmlns="http://hl7.org/fhir">
+      <AuditEvent xmlns="http://hl7.org/fhir">
         <id value="3"/>
         <meta>
           <versionId value="1"/>
@@ -242,8 +241,7 @@
         </meta>
         <text>
           <status value="generated"/>
-          <div 
-            xmlns="http://www.w3.org/1999/xhtml">22.09.2020 09:47: Jakob Wieder-Gesund created Access Level delegation-and-restricted till 31.12.2020 08:00 to Dr. med. Hans Allzeitbereit 
+          <div xmlns="http://www.w3.org/1999/xhtml">22.09.2020 09:47: Jakob Wieder-Gesund created Access Level delegation-and-restricted till 31.12.2020 08:00 to Dr. med. Hans Allzeitbereit 
           </div>
         </text>
         <type>

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -1,2 +1,20 @@
 == Suppressed Messages ==
 
+# Represents the XDSDocumentEntry.uniqueId
+Code System URI 'urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab' is unknown so the code cannot be validated
+
+# Build errors
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:repositoryUniqueId.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:homeCommunityID.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:EprDocumentTypeCode.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:title.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:repositoryUniqueId.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:homeCommunityID.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:EprDocumentTypeCode.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:title.value' for "value" cannot be resolved (valid targets: 261 targets)
+The link 'StructureDefinition-PolicyAuditEvent-definitions.html#AuditEvent.entity:Resource.detail:AccessLevel.value' for "value" cannot be resolved (valid targets: 204 targets)
+The link 'StructureDefinition-PolicyAuditEvent-definitions.html#AuditEvent.entity:Resource.detail:AccessLimitedToDate.value' for "value" cannot be resolved (valid targets: 204 targets)
+The link 'StructureDefinition-PolicyAuditEvent-definitions.html#AuditEvent.entity:Resource.detail:ProvideLevel.value' for "value" cannot be resolved (valid targets: 204 targets)
+The link 'StructureDefinition-PolicyAuditEvent-definitions.html#AuditEvent.entity:Resource.detail:AccessLevel.value' for "value" cannot be resolved (valid targets: 204 targets)
+The link 'StructureDefinition-PolicyAuditEvent-definitions.html#AuditEvent.entity:Resource.detail:AccessLimitedToDate.value' for "value" cannot be resolved (valid targets: 204 targets)
+The link 'StructureDefinition-PolicyAuditEvent-definitions.html#AuditEvent.entity:Resource.detail:ProvideLevel.value' for "value" cannot be resolved (valid targets: 204 targets)

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -8,7 +8,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * Added 'HpdAuditEvent' Profile and 'HpdAuditEventType' ValueSet.
    * Additional slice Bundle.entry:HpdAuditEvent in 'ChAtcIti81Response' profile.
 * Added examples:
-   * CH ATC - Audit Event for Document Metadata query (Profile: DocumentAuditEvent)
+   * CH ATC - Audit Event for Document Search (Profile: DocumentAuditEvent)
    * CH ATC - Audit Event for Group Entry Audit Event Content Profile (Profile: HpdAuditEvent)
 * Added 'STU Note' box, 'Change Log' and NPM package download link.
 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,0 +1,43 @@
+
+All significant changes to this FHIR implementation guide will be documented on this page.   
+
+### vx.x.x (2022-xx-xx)
+
+
+#### Added
+* Added 'HpdAuditEvent' Profile and 'HpdAuditEventType' ValueSet.
+   * Additional slice Bundle.entry:HpdAuditEvent in 'ChAtcIti81Response' profile.
+* Added examples:
+   * CH ATC - Audit Event for Document Metadata query (Profile: DocumentAuditEvent)
+   * CH ATC - Audit Event for Group Entry Audit Event Content Profile (Profile: HpdAuditEvent)
+* Added 'STU Note' box, 'Change Log' and NPM package download link.
+
+#### Changed / Updated
+* DocumentAuditEvent:
+   * Added slice AuditEvent.entity:Query
+   * Added slice AuditEvent.entity:Document.detail:title
+* Added the code 'ATC_DOC_SEARCH' to existing ValueSet 'DocumentAuditEventType'.
+* Updated description of the 'ChAtcIti81Response' profile and unified the notation in the IG.
+* Structural updates of the IG analogous to the further development of the IG Publisher. Removed elements in the differential which did not deviate from the core specification to clean the differential table of the profiles.
+
+#### Fixed
+* Fixed URL of the SearchParameter: http://fhir.ch/ig/ch-atc/StructureDefinition/AuditEvent-entity-identifier -> http://fhir.ch/ig/ch-atc/SearchParameter/AuditEvent-entity-identifier
+* Replaced invalid document type: birth certificate/radiology report -> record artifcat
+* Changed cardinalities:
+   * DocumentAuditEvent: 
+      * AuditEvent.entity: min 1 -> 0
+* Fixed typos. 
+
+### v3.1.0 (2020-06-11)
+Updated draft version:
+* Added SearchParameter 'AuditEvent entity.identifier'.
+* Changed CodeSystem agentRole from 'urn:oid:2.16.756.5.30.1.127.3.10.8' to 'urn:oid:2.16.756.5.30.1.127.3.10.14'
+* Introduction of dependence to implementation guide CH EPR Term.
+   * Removed all CodeSystems.
+   * Removed ValueSet 'EprPurposeOfUse'.
+   * Adapted URLs of the ValueSets.
+* Updated FHIR version from STU3 (v3.0.1) to R4 (v4.0.1).
+* Structural updates of the IG analogous to the further development of the IG Publisher (e.g. new template).
+
+### v1.2.0 (2019-03-01)
+Initial published draft version according to 'www.e-health-suisse.ch/fileadmin/user_upload/Dokumente/2019/E/190528_Entwurf_EPDV-EDI_E2A5_ATC_V1.9_e.pdf' (see on [e-health-suisse.ch](https://www.e-health-suisse.ch/beispielseiten/epd-projectathon/programmierhilfen-epd/relevante-spezifikationen.html#ATC)).

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -1,9 +1,13 @@
 ### Introduction
-This profile defines the audit trail consumption requirements a community has to provide for a patient.
-The profile CH ATC defines and precises the actors and transaction [ITI-81] of the [IHE IT Infrastructure Technical Framework
-Supplement Add RESTful Query to ATNA](http://www.ihe.net/uploadedFiles/Documents/ITI/IHE_ITI_Suppl_RESTful-ATNA.pdf) and defines the content of the Audit Messages. The different types of 
-the Audit Messages are based on the requirements for Document and Policy Access management in order to achieve the 
-Swiss regulation needs on the audit trail access by patients. These Audit Event types differ from the Audit Events which 
-have also to be logged according to the IHE / CH:ATNA requirements.
+This profile defines the audit trail consumption requirements a community has to provide for a patient. The profile CH ATC defines and precises the actors and transaction [ITI-81] of the [IHE IT Infrastructure Technical Framework Supplement Add RESTful Query to ATNA](http://www.ihe.net/uploadedFiles/Documents/ITI/IHE_ITI_Suppl_RESTful-ATNA.pdf) and defines the content of the Audit Messages. The different types of the Audit Messages are based on the requirements for Document and Policy Access management in order to achieve the Swiss regulation needs on the audit trail access by patients. These Audit Event types differ from the Audit Events which have also to be logged according to the IHE / CH:ATNA requirements.
 
 The CH ATC profile text in the National Integration Profiles (SR816.11, Annex 5, Extension 2) is normative, this implementation guide is informative. This implementation guide is built with [IG Publisher](https://confluence.hl7.org/display/FHIR/IG+Publisher+Documentation) from HL7. See [e-health-suisse.ch](https://www.e-health-suisse.ch/startseite.html) for more information about the Electronic Patient Record in Switzerland.
+
+<div markdown="1" class="stu-note">
+
+[Significant Changes, Open and Closed Issues](changelog.html)
+
+</div>
+
+
+**Download**: You can download this implementation guide in [NPM format](https://confluence.hl7.org/display/FHIR/NPM+Package+Specification) from [here](package.tgz).

--- a/input/pages/package-list.json
+++ b/input/pages/package-list.json
@@ -1,15 +1,15 @@
 {
   "package-id": "ch.fhir.ig.ch-atc",
   "title": "CH ATC (R4)",
-  "introduction": "Implementation Guide CH ATC",
+  "introduction": "Implementation Guide for CH ATC (Audit Trail Consumption)",
   "canonical": "http://fhir.ch/ig/ch-atc",
   "list": [
     {
-      "version": "dev",
+      "version": "current",
       "desc": "Continuous Integration Build (latest in version control)",
       "path": "http://build.fhir.org/ig/ehealthsuisse/ch-atc",
       "status": "ci-build",
-      "fhirVersion": "4.0.1"
+      "current": true
     },
     {
       "version": "3.1.0",
@@ -17,9 +17,9 @@
       "desc": "CH ATC (v3.1.0)",
       "path": "http://fhir.ch/ig/ch-atc",
       "status": "draft",
-      "fhirVersion": "4.0.1",
-      "current": true,
-      "sequence": "Draft"  
+      "sequence": "Draft",
+      "fhirversion": "4.0.1",
+      "current": true        
     },
     {
       "version": "1.2.0",
@@ -27,8 +27,9 @@
       "desc": "CH ATC (v1.2.0) - www.e-health-suisse.ch/fileadmin/user_upload/Dokumente/2019/E/190528_Entwurf_EPDV-EDI_E2A5_ATC_V1.9_e.pdf",
       "path": "http://fhir.ch/ig/ch-atc/1.2.0",
       "status": "draft",
-      "fhirVersion": "3.0.1",
-      "sequence": "Draft"
+      "sequence": "Draft",
+      "fhirversion": "3.0.1"
     }
-  ]
+  ],
+  "category": "National Base"
 }

--- a/input/pages/package-list.json
+++ b/input/pages/package-list.json
@@ -27,7 +27,7 @@
       "desc": "CH ATC (v1.2.0) - www.e-health-suisse.ch/fileadmin/user_upload/Dokumente/2019/E/190528_Entwurf_EPDV-EDI_E2A5_ATC_V1.9_e.pdf",
       "path": "http://fhir.ch/ig/ch-atc/1.2.0",
       "status": "draft",
-      "fhirVersion": "4.0.1",
+      "fhirVersion": "3.0.1",
       "sequence": "Draft"
     }
   ]

--- a/input/pages/package-list.json
+++ b/input/pages/package-list.json
@@ -27,7 +27,7 @@
       "desc": "CH ATC (v1.2.0) - www.e-health-suisse.ch/fileadmin/user_upload/Dokumente/2019/E/190528_Entwurf_EPDV-EDI_E2A5_ATC_V1.9_e.pdf",
       "path": "http://fhir.ch/ig/ch-atc/1.2.0",
       "status": "draft",
-      "fhirVersion": "3.0.1",
+      "fhirVersion": "4.0.1",
       "sequence": "Draft"
     }
   ]

--- a/input/resources/searchparameter/AuditEvent-entity-identifier.xml
+++ b/input/resources/searchparameter/AuditEvent-entity-identifier.xml
@@ -3,7 +3,7 @@
     <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
         <valueCode value="trial-use"/>
     </extension>
-    <url value="http://fhir.ch/ig/ch-atc/StructureDefinition/AuditEvent-entity-identifier"/>
+    <url value="http://fhir.ch/ig/ch-atc/SearchParameter/AuditEvent-entity-identifier"/>
     <version value="4.0.1"/>
     <name value="SPEntityIdentifier"/>
     <status value="draft"/>
@@ -24,7 +24,7 @@
             <value value="oliver.egger@ahdis.ch"/>
         </telecom>
     </contact>
-    <description value="This parameter specifies unique identifier for the object. The parameter value should be identified in accordance to the entity type"/>
+    <description value="This parameter specifies unique identifier for the object. The parameter value should be identified in accordance to the entity type."/>
     <code value="entity-identifier"/>
     <base value="AuditEvent"/>
     <type value="token"/>

--- a/input/resources/structuredefinition/AccessAuditTrailEvent.xml
+++ b/input/resources/structuredefinition/AccessAuditTrailEvent.xml
@@ -119,16 +119,12 @@
             <map value="role (PAT, REP)"/>
          </mapping>
       </element>
-      <element id="AuditEvent.agent.who">
-         <path value="AuditEvent.agent.who"/>
+      <element id="AuditEvent.agent.who.identifier">
+         <path value="AuditEvent.agent.who.identifier"/>
+         <min value="1"/>
+         <max value="1"/>
          <type>
-            <code value="Reference"/>
-            <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
-            <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
-            <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
-            <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
-            <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
-            <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
+            <code value="Identifier"/>
          </type>
          <mapping>
             <identity value="ch-atc"/>

--- a/input/resources/structuredefinition/AccessAuditTrailEvent.xml
+++ b/input/resources/structuredefinition/AccessAuditTrailEvent.xml
@@ -1,15 +1,15 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
-   <id value="AccessAuditTrailEvent"></id>
+   <id value="AccessAuditTrailEvent"/>
    <text>
-      <status value="additional"></status>
+      <status value="additional"/>
       <div xmlns="http://www.w3.org/1999/xhtml">StructureDefinition for the AccessAuditTrailEvent.</div>
    </text>
-   <url value="http://fhir.ch/ig/ch-atc/StructureDefinition/AccessAuditTrailEvent"></url>
-   <name value="AccessAuditTrailEvent"></name>
-   <title value="AccessAuditTrailEvent"></title>
-   <status value="active"></status>
-   <experimental value="false"></experimental>
-   <date value="2018-05-28"></date>
+   <url value="http://fhir.ch/ig/ch-atc/StructureDefinition/AccessAuditTrailEvent"/>
+   <name value="AccessAuditTrailEvent"/>
+   <title value="AccessAuditTrailEvent"/>
+   <status value="active"/>
+   <experimental value="false"/>
+   <date value="2018-05-28"/>
    <publisher value="eHealth Suisse"/>
    <contact>
       <name value="eHealth Suisse"/>
@@ -25,98 +25,98 @@
          <value value="oliver.egger@ahdis.ch"/>
       </telecom>
    </contact>
-   <description value="This profile defines the content of the access audit trail event which a community has to provide for a patients audit trail."></description>
+   <description value="This profile defines the content of the access audit trail event which a community has to provide for a patients audit trail."/>
    <jurisdiction>
       <coding>
-         <system value="urn:iso:std:iso:3166"></system>
-         <code value="CH"></code>
+         <system value="urn:iso:std:iso:3166"/>
+         <code value="CH"/>
       </coding>
    </jurisdiction>
-   <copyright value="CC-BY-SA-4.0"></copyright>
-   <fhirVersion value="4.0.1"></fhirVersion>
+   <copyright value="CC-BY-SA-4.0"/>
+   <fhirVersion value="4.0.1"/>
    <mapping>
-      <identity value="ch-atc"></identity>
-      <uri value="https://www.bag.admin.ch/bag/en/home.html"></uri>
-      <name value="Mapping to CH ATC"></name>
+      <identity value="ch-atc"/>
+      <uri value="https://www.bag.admin.ch/bag/en/home.html"/>
+      <name value="Mapping to CH ATC"/>
    </mapping>
-   <kind value="resource"></kind>
-   <abstract value="false"></abstract>
-   <type value="AuditEvent"></type>
-   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/AuditEvent"></baseDefinition>
-   <derivation value="constraint"></derivation>
+   <kind value="resource"/>
+   <abstract value="false"/>
+   <type value="AuditEvent"/>
+   <baseDefinition value="http://hl7.org/fhir/StructureDefinition/AuditEvent"/>
+   <derivation value="constraint"/>
    <differential>
       <element id="AuditEvent">
-         <path value="AuditEvent"></path>
-         <short value="Access Audit Trail Event Content Profile"></short>
+         <path value="AuditEvent"/>
+         <short value="Access Audit Trail Event Content Profile"/>
          <constraint>
-            <key value="ch-atc-aae-1"></key>
-            <severity value="error"></severity>
-            <human value="subtype needs to be fixed to ATC_LOG_READ"></human>
-            <expression value="subtype.exists() and subtype.count()=1 and subtype[0].code='ATC_LOG_READ'"></expression>
+            <key value="ch-atc-aae-1"/>
+            <severity value="error"/>
+            <human value="subtype needs to be fixed to ATC_LOG_READ"/>
+            <expression value="subtype.exists() and subtype.count()=1 and subtype[0].code='ATC_LOG_READ'"/>
          </constraint>
       </element>
       
       <element id="AuditEvent.type">
-         <path value="AuditEvent.type"></path>
+         <path value="AuditEvent.type"/>
          <binding>
             <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-               <valueString value="AuditEventType"></valueString>
+               <valueString value="AuditEventType"/>
             </extension>
-            <strength value="extensible"></strength>
-            <description value="Type of event."></description>
-            <valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"></valueSet>
+            <strength value="extensible"/>
+            <description value="Type of event."/>
+            <valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"/>
          </binding>
       </element>
 
       <element id="AuditEvent.subtype">
-         <path value="AuditEvent.subtype"></path>
-         <min value="1"></min>
-         <max value="1"></max>
+         <path value="AuditEvent.subtype"/>
+         <min value="1"/>
+         <max value="1"/>
          <binding>
             <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-               <valueString value="ConditionKind"></valueString>
+               <valueString value="ConditionKind"/>
             </extension>
-            <strength value="required"></strength>
-            <description value="Audit Trail Event Type"></description>
-            <valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/AccessAuditTrailEventType"></valueSet>
+            <strength value="required"/>
+            <description value="Audit Trail Event Type"/>
+            <valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/AccessAuditTrailEventType"/>
          </binding>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="Event Type"></map>
+            <identity value="ch-atc"/>
+            <map value="Event Type"/>
          </mapping>
       </element>
 
       <element id="AuditEvent.recorded">
-         <path value="AuditEvent.recorded"></path>
+         <path value="AuditEvent.recorded"/>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="Event Date and Time"></map>
+            <identity value="ch-atc"/>
+            <map value="Event Date and Time"/>
          </mapping>
       </element>
 
       <element id="AuditEvent.agent">
-         <path value="AuditEvent.agent"></path>
-         <short value="Patient, repeated if representative"></short>
+         <path value="AuditEvent.agent"/>
+         <short value="Patient, repeated if representative"/>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="Participants"></map>
+            <identity value="ch-atc"/>
+            <map value="Participants"/>
          </mapping>
       </element>
       <element id="AuditEvent.agent.role">
-         <path value="AuditEvent.agent.role"></path>
-         <min value="1"></min>
-         <max value="1"></max>
+         <path value="AuditEvent.agent.role"/>
+         <min value="1"/>
+         <max value="1"/>
          <binding>
             <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-               <valueString value="ConditionKind"></valueString>
+               <valueString value="ConditionKind"/>
             </extension>
-            <strength value="required"></strength>
-            <description value="EPR Participant"></description>
-            <valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"></valueSet>
+            <strength value="required"/>
+            <description value="EPR Participant"/>
+            <valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"/>
          </binding>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="role (PAT, REP)"></map>
+            <identity value="ch-atc"/>
+            <map value="role (PAT, REP)"/>
          </mapping>
       </element>
       <element id="AuditEvent.agent.who">
@@ -131,89 +131,89 @@
             <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
          </type>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="applicable identifier"></map>
+            <identity value="ch-atc"/>
+            <map value="applicable identifier"/>
          </mapping>
       </element>
       <element id="AuditEvent.agent.name">
-         <path value="AuditEvent.agent.name"></path>
-         <definition value="AttributeStatement/Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject- id']/AttributeValue"></definition>
-         <min value="1"></min>
+         <path value="AuditEvent.agent.name"/>
+         <definition value="AttributeStatement/Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject- id']/AttributeValue"/>
+         <min value="1"/>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="Name"></map>
+            <identity value="ch-atc"/>
+            <map value="Name"/>
          </mapping>
       </element>
       <element id="AuditEvent.agent.requestor">
-         <path value="AuditEvent.agent.requestor"></path>
+         <path value="AuditEvent.agent.requestor"/>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="if participant is Initiator"></map>
+            <identity value="ch-atc"/>
+            <map value="if participant is Initiator"/>
          </mapping>
       </element>
 
       <element id="AuditEvent.entity">
-         <path value="AuditEvent.entity"></path>
+         <path value="AuditEvent.entity"/>
          <slicing>
             <discriminator>
-               <type value="value"></type>
-               <path value="type.code"></path>
+               <type value="value"/>
+               <path value="type.code"/>
             </discriminator>
             <discriminator>
-               <type value="value"></type>
-               <path value="role.code"></path>
+               <type value="value"/>
+               <path value="role.code"/>
             </discriminator>
-            <rules value="open"></rules>
+            <rules value="open"/>
          </slicing>
       </element>
 
       <!-- Slice Patient -->
       <element id="AuditEvent.entity:Patient">
-         <path value="AuditEvent.entity"></path>
-         <sliceName value="Patient"></sliceName>
-         <short value="Patient"></short>
-         <min value="1"></min>
-         <max value="1"></max>
+         <path value="AuditEvent.entity"/>
+         <sliceName value="Patient"/>
+         <short value="Patient"/>
+         <min value="1"/>
+         <max value="1"/>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="Patient"></map>
+            <identity value="ch-atc"/>
+            <map value="Patient"/>
          </mapping>
       </element>
       <element id="AuditEvent.entity:Patient.what.identifier">
-         <path value="AuditEvent.entity.what.identifier"></path>
-         <short value="Patient Id (EPR-SPID)"></short>
-         <min value="1"></min>
-         <max value="1"></max>
+         <path value="AuditEvent.entity.what.identifier"/>
+         <short value="Patient Id (EPR-SPID)"/>
+         <min value="1"/>
+         <max value="1"/>
          <type>
-            <code value="Identifier"></code>
+            <code value="Identifier"/>
          </type>
          <mapping>
-            <identity value="ch-atc"></identity>
-            <map value="EPR-SPID"></map>
+            <identity value="ch-atc"/>
+            <map value="EPR-SPID"/>
          </mapping>
       </element>
       <element id="AuditEvent.entity:Patient.what.identifier.system">
-         <path value="AuditEvent.entity.what.identifier.system"></path>
-         <min value="1"></min>
-         <fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.3"></fixedUri>
+         <path value="AuditEvent.entity.what.identifier.system"/>
+         <min value="1"/>
+         <fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.3"/>
       </element>
       <element id="AuditEvent.entity:Patient.type">
-         <path value="AuditEvent.entity.type"></path>
-         <min value="1"></min>
+         <path value="AuditEvent.entity.type"/>
+         <min value="1"/>
       </element>
       <element id="AuditEvent.entity:Patient.type.code">
-         <path value="AuditEvent.entity.type.code"></path>
-         <min value="1"></min>
-         <fixedCode value="1"></fixedCode>
+         <path value="AuditEvent.entity.type.code"/>
+         <min value="1"/>
+         <fixedCode value="1"/>
       </element>
       <element id="AuditEvent.entity:Patient.role">
-         <path value="AuditEvent.entity.role"></path>
-         <min value="1"></min>
+         <path value="AuditEvent.entity.role"/>
+         <min value="1"/>
       </element>
       <element id="AuditEvent.entity:Patient.role.code">
-         <path value="AuditEvent.entity.role.code"></path>
-         <min value="1"></min>
-         <fixedCode value="1"></fixedCode>
+         <path value="AuditEvent.entity.role.code"/>
+         <min value="1"/>
+         <fixedCode value="1"/>
       </element>
    </differential>
 </StructureDefinition>

--- a/input/resources/structuredefinition/AccessAuditTrailEvent.xml
+++ b/input/resources/structuredefinition/AccessAuditTrailEvent.xml
@@ -2,7 +2,7 @@
    <id value="AccessAuditTrailEvent"></id>
    <text>
       <status value="additional"></status>
-      <div xmlns="http://www.w3.org/1999/xhtml"> StructureDefinition for the AccessAuditTrailEvent. </div>
+      <div xmlns="http://www.w3.org/1999/xhtml">StructureDefinition for the AccessAuditTrailEvent.</div>
    </text>
    <url value="http://fhir.ch/ig/ch-atc/StructureDefinition/AccessAuditTrailEvent"></url>
    <name value="AccessAuditTrailEvent"></name>
@@ -25,7 +25,7 @@
          <value value="oliver.egger@ahdis.ch"/>
       </telecom>
    </contact>
-   <description value="This profile defines the content of the access audit trail event which a community has to provide for a patients audit trail. "></description>
+   <description value="This profile defines the content of the access audit trail event which a community has to provide for a patients audit trail."></description>
    <jurisdiction>
       <coding>
          <system value="urn:iso:std:iso:3166"></system>
@@ -39,11 +39,6 @@
       <uri value="https://www.bag.admin.ch/bag/en/home.html"></uri>
       <name value="Mapping to CH ATC"></name>
    </mapping>
-   <mapping>
-      <identity value="dicom"></identity>
-      <uri value="http://nema.org/dicom"></uri>
-      <name value="DICOM Tag Mapping"></name>
-   </mapping>
    <kind value="resource"></kind>
    <abstract value="false"></abstract>
    <type value="AuditEvent"></type>
@@ -53,32 +48,16 @@
       <element id="AuditEvent">
          <path value="AuditEvent"></path>
          <short value="Access Audit Trail Event Content Profile"></short>
-         <definition value="Access Audit Trail Event Content Profile"></definition>
-         <comment value="Based on ATNA (RFC 3881)."></comment>
-         <min value="0"></min>
-         <max value="*"></max>
          <constraint>
             <key value="ch-atc-aae-1"></key>
             <severity value="error"></severity>
             <human value="subtype needs to be fixed to ATC_LOG_READ"></human>
             <expression value="subtype.exists() and subtype.count()=1 and subtype[0].code='ATC_LOG_READ'"></expression>
          </constraint>
-         <mapping>
-            <identity value="dicom"></identity>
-            <map value="Message"></map>
-         </mapping>
       </element>
+      
       <element id="AuditEvent.type">
          <path value="AuditEvent.type"></path>
-         <short value="Type/identifier of event"></short>
-         <definition value="Identifier for a family of the event.  For example, a menu item, program, rule, policy,       function code, application name or URL. It identifies the performed function."></definition>
-         <requirements value="This identifies the performed function. For &quot;Execute&quot; Event Action Code audit       records, this identifies the application function performed."></requirements>
-         <min value="1"></min>
-         <max value="1"></max>
-         <type>
-            <code value="Coding"></code>
-         </type>
-
          <binding>
             <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
                <valueString value="AuditEventType"></valueString>
@@ -87,30 +66,12 @@
             <description value="Type of event."></description>
             <valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"></valueSet>
          </binding>
-         <mapping>
-            <identity value="rim"></identity>
-            <map value=".code (type, subtype and action are pre-coordinated or sent as translations)"></map>
-         </mapping>
-         <mapping>
-            <identity value="dicom"></identity>
-            <map value="EventId"></map>
-         </mapping>
-         <mapping>
-            <identity value="w3c.prov"></identity>
-            <map value="Activity"></map>
-         </mapping>
-         <mapping>
-            <identity value="w5"></identity>
-            <map value="what"></map>
-         </mapping>
       </element>
+
       <element id="AuditEvent.subtype">
          <path value="AuditEvent.subtype"></path>
          <min value="1"></min>
          <max value="1"></max>
-         <type>
-            <code value="Coding"></code>
-         </type>
          <binding>
             <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
                <valueString value="ConditionKind"></valueString>
@@ -124,39 +85,18 @@
             <map value="Event Type"></map>
          </mapping>
       </element>
+
       <element id="AuditEvent.recorded">
          <path value="AuditEvent.recorded"></path>
-         <short value="Time when the event was recorded"></short>
-         <definition value="The time when the event was recorded."></definition>
-         <comment value="In a distributed system, some sort of common time base (e.g. an NTP [RFC1305] server)       is a good implementation tactic."></comment>
-         <requirements value="This ties an event to a specific date and time. Security audits typically require a consistent       time base (e.g. UTC), to eliminate time-zone issues arising from geographical distribution."></requirements>
-         <min value="1"></min>
-         <max value="1"></max>
-         <type>
-            <code value="instant"></code>
-         </type>
-
          <mapping>
             <identity value="ch-atc"></identity>
             <map value="Event Date and Time"></map>
          </mapping>
       </element>
+
       <element id="AuditEvent.agent">
          <path value="AuditEvent.agent"></path>
          <short value="Patient, repeated if representative"></short>
-         <definition value="Patient, repeated if representative"></definition>
-         <comment value="Several agents may be associated (i.e. have some responsibility for an activity) with       an event or activity.For example, an activity may be initiated by one user for other users or involve more       than one user. However, only one user may be the initiator/requestor for the activity."></comment>
-         <requirements value="An agent can be a person, an organization, software, device, or other actors that may       be ascribed responsibility."></requirements>
-         <alias value="ActiveParticipant"></alias>
-         <min value="1"></min>
-         <max value="*"></max>
-         <type>
-            <code value="BackboneElement"></code>
-         </type>
-         <mapping>
-            <identity value="dicom"></identity>
-            <map value="ActiveParticipant"></map>
-         </mapping>
          <mapping>
             <identity value="ch-atc"></identity>
             <map value="Participants"></map>
@@ -164,27 +104,16 @@
       </element>
       <element id="AuditEvent.agent.role">
          <path value="AuditEvent.agent.role"></path>
-         <short value="Agent role in the event"></short>
-         <definition value="The security role that the user was acting under, that come from local codes defined by       the access control security system (e.g. RBAC, ABAC) used in the local context."></definition>
-         <comment value="Should be roles relevant to the event. Should  not be an exhaustive list of roles."></comment>
-         <requirements value="This value ties an audited event to a user's role(s). It is an optional value that might       be used to group events for analysis by user functional role categories."></requirements>
          <min value="1"></min>
          <max value="1"></max>
-         <type>
-            <code value="CodeableConcept"></code>
-         </type>
          <binding>
             <extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
                <valueString value="ConditionKind"></valueString>
             </extension>
             <strength value="required"></strength>
-            <description value="EprParticipant"></description>
+            <description value="EPR Participant"></description>
             <valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"></valueSet>
          </binding>
-         <mapping>
-            <identity value="dicom"></identity>
-            <map value="RoleIdCode"></map>
-         </mapping>
          <mapping>
             <identity value="ch-atc"></identity>
             <map value="role (PAT, REP)"></map>
@@ -192,13 +121,6 @@
       </element>
       <element id="AuditEvent.agent.who">
          <path value="AuditEvent.agent.who"/>
-         <short value="Identifier of who"/>
-         <definition value="Reference to who this agent is that was involved in the event."/>
-         <comment value="Where a User ID is available it will go into who.identifier."/>
-         <requirements value="This field ties an audit event to a specific resource or identifier."/>
-         <alias value="userId"/>
-         <min value="0"/>
-         <max value="1"/>
          <type>
             <code value="Reference"/>
             <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
@@ -209,29 +131,14 @@
             <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
          </type>
          <mapping>
-            <identity value="dicom"></identity>
-            <map value="UserId"></map>
-         </mapping>
-         <mapping>
             <identity value="ch-atc"></identity>
             <map value="applicable identifier"></map>
          </mapping>
       </element>
       <element id="AuditEvent.agent.name">
          <path value="AuditEvent.agent.name"></path>
-         <short value="Human-meaningful name for the agent"></short>
          <definition value="AttributeStatement/Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject- id']/AttributeValue"></definition>
-         <requirements value="The User ID and Authorization User ID may be internal or otherwise obscure values. This       field assists the auditor in identifying the actual user."></requirements>
          <min value="1"></min>
-         <max value="1"></max>
-         <type>
-            <code value="string"></code>
-         </type>
-
-         <mapping>
-            <identity value="dicom"></identity>
-            <map value="UserName"></map>
-         </mapping>
          <mapping>
             <identity value="ch-atc"></identity>
             <map value="Name"></map>
@@ -239,33 +146,12 @@
       </element>
       <element id="AuditEvent.agent.requestor">
          <path value="AuditEvent.agent.requestor"></path>
-         <short value="Whether user is initiator"></short>
-         <definition value="Indicator that the participant is the initiator for the event being audited."></definition>
-         <comment value="There can only be one initiator. If the initiator is not clear, then do not choose any       one agent as the initiator."></comment>
-         <requirements value="This value is used to distinguish between requestor-users and recipient-users. For example,       one person may initiate a report-output to be sent to another user."></requirements>
-         <min value="1"></min>
-         <max value="1"></max>
-         <type>
-            <code value="boolean"></code>
-         </type>
-
-         <mapping>
-            <identity value="rim"></identity>
-            <map value="If participation.typeCode was author, then true"></map>
-         </mapping>
-         <mapping>
-            <identity value="dicom"></identity>
-            <map value="UserIsRequestor"></map>
-         </mapping>
-         <mapping>
-            <identity value="w5"></identity>
-            <map value="who"></map>
-         </mapping>
          <mapping>
             <identity value="ch-atc"></identity>
             <map value="if participant is Initiator"></map>
          </mapping>
       </element>
+
       <element id="AuditEvent.entity">
          <path value="AuditEvent.entity"></path>
          <slicing>
@@ -279,116 +165,55 @@
             </discriminator>
             <rules value="open"></rules>
          </slicing>
-         <short value="Data or objects used"></short>
-         <definition value="Specific instances of data or objects that have been accessed."></definition>
-         <comment value="Required unless the values for event identification, agent identification, and audit source       identification are sufficient to document the entire auditable event. Because events may       have more than one entity, this group can be a repeating set of values."></comment>
-         <requirements value="The event may have other entities involved."></requirements>
-         <alias value="ParticipantObject"></alias>
-         <min value="0"></min>
-         <max value="*"></max>
-         <type>
-            <code value="BackboneElement"></code>
-         </type>
-         <constraint>
-            <key value="sev-1"></key>
-            <severity value="error"></severity>
-            <human value="Either a name or a query (NOT both)"></human>
-            <expression value="name.empty() or query.empty()"></expression>
-            <xpath value="not(exists(f:name)) or not(exists(f:query))"></xpath>
-         </constraint>
-         <mapping>
-            <identity value="w5"></identity>
-            <map value="FiveWs.what[x]"></map>
-         </mapping>
-         <mapping>
-            <identity value="rim"></identity>
-            <map value=".outboundRelationship[typeCode=SUBJ].target  or .participation[typeCode=SBJ].role"></map>
-         </mapping>
-         <mapping>
-            <identity value="dicom"></identity>
-            <map value="ParticipantObjectIdentification"></map>
-         </mapping>
-         <mapping>
-            <identity value="w3c.prov"></identity>
-            <map value="Entity"></map>
-         </mapping>
-         <mapping>
-            <identity value="fhirprovenance"></identity>
-            <map value="Provenance.target, Provenance.entity"></map>
-         </mapping>
       </element>
+
+      <!-- Slice Patient -->
       <element id="AuditEvent.entity:Patient">
          <path value="AuditEvent.entity"></path>
          <sliceName value="Patient"></sliceName>
          <short value="Patient"></short>
          <min value="1"></min>
          <max value="1"></max>
-
          <mapping>
             <identity value="ch-atc"></identity>
             <map value="Patient"></map>
          </mapping>
       </element>
-      <element id="AuditEvent.entity.what.identifier:Patient">
+      <element id="AuditEvent.entity:Patient.what.identifier">
          <path value="AuditEvent.entity.what.identifier"></path>
          <short value="Patient Id (EPR-SPID)"></short>
-         <definition value="Patient Id (EPR-SPID)"></definition>
-         <comment value="."></comment>
          <min value="1"></min>
          <max value="1"></max>
          <type>
             <code value="Identifier"></code>
          </type>
          <mapping>
-            <identity value="dicom"></identity>
-            <map value="ParticipantObjectID and ParticipantObjectIDTypeCode"></map>
-         </mapping>
-         <mapping>
             <identity value="ch-atc"></identity>
             <map value="EPR-SPID"></map>
          </mapping>
       </element>
-      <element id="AuditEvent.entity.what.identifier.system:Patient">
+      <element id="AuditEvent.entity:Patient.what.identifier.system">
          <path value="AuditEvent.entity.what.identifier.system"></path>
          <min value="1"></min>
          <fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.3"></fixedUri>
       </element>
-      <element id="AuditEvent.entity.type:Patient">
+      <element id="AuditEvent.entity:Patient.type">
          <path value="AuditEvent.entity.type"></path>
-         <short value="Type of entity involved"></short>
-         <definition value="The type of the object that was involved in this audit event."></definition>
-         <comment value="This value is distinct from the user's role or any user relationship to the entity."></comment>
-         <requirements value="To describe the object being acted upon. In addition to queries on the subject of the       action in an auditable event, it is also important to be able to query on the object type       for the action."></requirements>
          <min value="1"></min>
-         <max value="1"></max>
-         <type>
-            <code value="Coding"></code>
-         </type>
-
       </element>
-      <element id="AuditEvent.entity.type.code:Patient">
+      <element id="AuditEvent.entity:Patient.type.code">
          <path value="AuditEvent.entity.type.code"></path>
          <min value="1"></min>
          <fixedCode value="1"></fixedCode>
-
       </element>
-      <element id="AuditEvent.entity.role:Patient">
+      <element id="AuditEvent.entity:Patient.role">
          <path value="AuditEvent.entity.role"></path>
-         <short value="What role the entity played"></short>
-         <definition value="Code representing the role the entity played in the event being audited."></definition>
-         <requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type       of entity, based on the application role it serves."></requirements>
          <min value="1"></min>
-         <max value="1"></max>
-         <type>
-            <code value="Coding"></code>
-         </type>
-
       </element>
-      <element id="AuditEvent.entity.role.code:Patient">
+      <element id="AuditEvent.entity:Patient.role.code">
          <path value="AuditEvent.entity.role.code"></path>
          <min value="1"></min>
          <fixedCode value="1"></fixedCode>
-
       </element>
    </differential>
 </StructureDefinition>

--- a/input/resources/structuredefinition/CH-ATC.ITI-81.Response.fhirpath.xml
+++ b/input/resources/structuredefinition/CH-ATC.ITI-81.Response.fhirpath.xml
@@ -37,7 +37,7 @@
 		</coding>
 	</jurisdiction>
 	<copyright value="CC-BY-SA-4.0" />
-	<fhirVersion value="3.0.1" />
+	<fhirVersion value="4.0.1" />
 	<kind value="resource" />
 	<abstract value="false" />
 	<type value="Bundle" />
@@ -55,7 +55,7 @@
 				<!-- ok              <expression value="entry.all(resource.exists())"/> -->
 				<!-- ok with patch             <expression value="entry.all(resource.conformsTo(&#39;http://hl7.org/fhir/StructureDefinition/Resource&#39;))"/> -->
 				<!-- ok with patch              <expression value="entry.all(resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent'))"/>  -->
-				<expression value="entry.all(resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent') or resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/PolicyAuditEvent') or resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/AccessAuditTrail'))"/>
+				<expression value="entry.all(resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent') or resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/PolicyAuditEvent') or resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/AccessAuditTrail') or resource.conformsTo('http://fhir.ch/ig/ch-atc/StructureDefinition/HpdAuditEvent'))"/>
 			</constraint>
 		</element>
 		<element id="Bundle.type">

--- a/input/resources/structuredefinition/CH-ATC.ITI-81.Response.fhirpath.xml
+++ b/input/resources/structuredefinition/CH-ATC.ITI-81.Response.fhirpath.xml
@@ -30,7 +30,7 @@
 			<value value="oliver.egger@ahdis.ch"/>
 		</telecom>
 	</contact>
-	<description value="Implementation Guide for CH ATC see Audit Trail Consumption" />
+	<description value="This profile defines the response to the [ITI-81] query. The response is a search set including all audit events which a community has to provide for a patients audit trail." />
 	<jurisdiction>
 		<coding>
 			<system value="urn:iso:std:iso:3166"/>

--- a/input/resources/structuredefinition/CH-ATC.ITI-81.Response.fhirpath.xml
+++ b/input/resources/structuredefinition/CH-ATC.ITI-81.Response.fhirpath.xml
@@ -11,6 +11,7 @@
 	</text>
 	<url value="http://fhir.ch/ig/ch-atc/StructureDefinition/CH-ATC.ITI-81.Response" />
 	<name value="ChAtcIti81Response" />
+	<title value="ChAtcIti81Response" />
 	<status value="active" />
 	<experimental value="false" />
 	<date value="2018-05-14" />

--- a/input/resources/structuredefinition/CH-ATC.ITI-81.Response.xml
+++ b/input/resources/structuredefinition/CH-ATC.ITI-81.Response.xml
@@ -12,6 +12,7 @@
 	</text>
 	<url value="http://fhir.ch/ig/ch-atc/StructureDefinition/CH-ATC.ITI-81.Response" />
 	<name value="ChAtcIti81Response" />
+	<title value="ChAtcIti81Response" />
 	<status value="active" />
 	<experimental value="false" />
 	<date value="2018-05-14" />

--- a/input/resources/structuredefinition/CH-ATC.ITI-81.Response.xml
+++ b/input/resources/structuredefinition/CH-ATC.ITI-81.Response.xml
@@ -31,7 +31,7 @@
 			<value value="oliver.egger@ahdis.ch"/>
 		</telecom>
 	</contact>
-	<description value="Implementation Guide for CH ATC see Audit Trail Consumption" />
+	<description value="This profile defines the response to the [ITI-81] query. The response is a search set including all audit events which a community has to provide for a patients audit trail." />
 	<jurisdiction>
 		<coding>
 			<system value="urn:iso:std:iso:3166"/>

--- a/input/resources/structuredefinition/CH-ATC.ITI-81.Response.xml
+++ b/input/resources/structuredefinition/CH-ATC.ITI-81.Response.xml
@@ -38,7 +38,7 @@
 		</coding>
 	</jurisdiction>
 	<copyright value="CC-BY-SA-4.0" />
-	<fhirVersion value="3.0.1" />
+	<fhirVersion value="4.0.1" />
 	<kind value="resource" />
 	<abstract value="false" />
 	<type value="Bundle" />
@@ -122,6 +122,26 @@
 			<type>
 				<code value="AuditEvent" />
 				<profile value="http://fhir.ch/ig/ch-atc/StructureDefinition/AccessAuditTrailEvent" />
+			</type>
+			<mustSupport value="true" />
+		</element>
+		<element id="Bundle.entry:HpdAuditEvent">
+			<path value="Bundle.entry" />
+			<sliceName value="HpdAuditEvent" />
+			<short value="AuditEvent" />
+			<min value="0" />
+			<max value="*" />
+		</element>
+		<element id="Bundle.entry:HpdAuditEvent.fullUrl">
+			<path value="Bundle.entry.fullUrl" />
+			<min value="0" />
+		</element>
+		<element id="Bundle.entry:HpdAuditEvent.resource">
+			<path value="Bundle.entry.resource" />
+			<min value="0" />
+			<type>
+				<code value="AuditEvent" />
+				<profile value="http://fhir.ch/ig/ch-atc/StructureDefinition/HpdAuditEvent" />
 			</type>
 			<mustSupport value="true" />
 		</element>

--- a/input/resources/structuredefinition/DocumentAuditEvent.xml
+++ b/input/resources/structuredefinition/DocumentAuditEvent.xml
@@ -431,7 +431,7 @@
 			</type>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="patient EPRSPID"/>
+				<map value="QueryType"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.entity:Query.type">

--- a/input/resources/structuredefinition/DocumentAuditEvent.xml
+++ b/input/resources/structuredefinition/DocumentAuditEvent.xml
@@ -419,7 +419,7 @@
 		</element>
 		<element id="AuditEvent.entity:Query.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
-			<short value="XDSQueryEntry.uniqueId" />
+			<short value="Query ID (UUID)" />
 			<min value="1"/>
 			<max value="1"/>
 			<type>
@@ -427,7 +427,7 @@
 			</type>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="QueryType"/>
+				<map value="Stored Query ID (UUID)"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.entity:Query.type">

--- a/input/resources/structuredefinition/DocumentAuditEvent.xml
+++ b/input/resources/structuredefinition/DocumentAuditEvent.xml
@@ -28,7 +28,7 @@
 			<value value="oliver.egger@ahdis.ch"/>
 		</telecom>
 	</contact>
-	<description value="This profile defines the content of the document audit events which a community has to provide for a patients audit trail. " />
+	<description value="This profile defines the content of the document audit events which a community has to provide for a patients audit trail." />
 	<jurisdiction>
 		<coding>
 			<system value="urn:iso:std:iso:3166"/>
@@ -42,11 +42,6 @@
 		<uri value="https://www.bag.admin.ch/bag/en/home.html" />
 		<name value="Mapping to CH ATC" />
 	</mapping>
-	<mapping>
-		<identity value="dicom"/>
-		<uri value="http://nema.org/dicom"/>
-		<name value="DICOM Tag Mapping"/>
-	</mapping>
 	<kind value="resource" />
 	<abstract value="false" />
 	<type value="AuditEvent" />
@@ -56,35 +51,17 @@
 		<element id="AuditEvent">
 			<path value="AuditEvent"/>
 			<short value="Document Audit Trail Content Profile"/>
-			<definition value="Document Audit Trail Content Profil"/>
-			<comment value="Based on ATNA (RFC 3881)."/>
-			<min value="0"/>
-			<max value="*"/>
 			<constraint>
 				<key value="ch-atc-dae-1"/>
 				<severity value="error"/>
 				<human value="subtype needs to be fixed to ValueSet DocumentAuditEventType"/>
-				<!--				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/DocumentAuditEventType')"/>  member of not implemented yet -->
+				<!-- <expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/DocumentAuditEventType')"/>  member of not implemented yet -->
 				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].code.startsWith('ATC_DOC')"/>
 			</constraint>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="Message"/>
-			</mapping>
 		</element>
+
 		<element id="AuditEvent.type">
 			<path value="AuditEvent.type"/>
-			<short value="Type/identifier of event"/>
-			<definition value="Identifier for a family of the event.  For example, a menu item, program, rule, policy,
-       function code, application name or URL. It identifies the performed function."/>
-			<requirements value="This identifies the performed function. For &quot;Execute&quot; Event Action Code audit
-       records, this identifies the application function performed."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="AuditEventType"/>
@@ -93,23 +70,8 @@
 				<description value="Type of event."/>
 				<valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"/>
 			</binding>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".code (type, subtype and action are pre-coordinated or sent as translations)"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventId"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Activity"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="what"/>
-			</mapping>
 		</element>
+
 		<element id="AuditEvent.subtype">
 			<path value="AuditEvent.subtype"/>
 			<slicing>
@@ -120,15 +82,6 @@
 				<rules value="open"/>
 			</slicing>
 			<min value="1"/>
-			<max value="*"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventTypeCode"/>
-			</mapping>
 		</element>
 		<element id="AuditEvent.subtype:DocumentAuditEventType">
 			<path value="AuditEvent.subtype"/>
@@ -136,7 +89,6 @@
 			<short value="DocumentAuditEventType" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
@@ -155,76 +107,36 @@
 			<min value="1"/>
 			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
 		</element>
+
 		<element id="AuditEvent.recorded">
 			<path value="AuditEvent.recorded"/>
-			<short value="Time when the event was recorded"/>
-			<definition value="The time when the event was recorded."/>
-			<comment value="In a distributed system, some sort of common time base (e.g. an NTP [RFC1305] server)
-       is a good implementation tactic."/>
-			<requirements value="This ties an event to a specific date and time. Security audits typically require a consistent
-       time base (e.g. UTC), to eliminate time-zone issues arising from geographical distribution."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="instant"/>
-			</type>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Event Date and Time"/>
 			</mapping>
 		</element>
+
 		<element id="AuditEvent.purposeOfEvent">
 			<path value="AuditEvent.purposeOfEvent"/>
-			<short value="The purposeOfUse of the event"/>
-			<definition value="The purposeOfUse (reason) that was used during the event being recorded."/>
-			<comment value="Use AuditEvent.agent.purposeOfUse when you know that it is specific to the agent, otherwise
-       use AuditEvent.purposeOfEvent. For example, during a machine-to-machine transfer it might
-       not be obvious to the audit system who caused the event, but it does know why."/>
 			<min value="1"/>
 			<max value="1"/>
-			<type>
-				<code value="CodeableConcept"/>
-			</type>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
 				</extension>
 				<strength value="required"/>
-				<description value="EprPurposeOfUse"/>
+				<description value="EPR Purpose of Use"/>
 				<valueSet value="http://fhir.ch/ig/ch-epr-term/ValueSet/EprPurposeOfUse"/>
 			</binding>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventPurposeOfUse"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="PurposeOfUse"/>
 			</mapping>
 		</element>
+
 		<element id="AuditEvent.agent">
 			<path value="AuditEvent.agent"/>
 			<short value="Participants"/>
-			<definition value="Participants"/>
-			<comment value="Several agents may be associated (i.e. have some responsibility for an activity) with
-       an event or activity.
-
-For example, an activity may be initiated by one user for other users or involve more
-       than one user. However, only one user may be the initiator/requestor for the activity."/>
-			<requirements value="An agent can be a person, an organization, software, device, or other actors that may
-       be ascribed responsibility."/>
-			<alias value="ActiveParticipant"/>
-			<min value="1"/>
-			<max value="*"/>
-			<type>
-				<code value="BackboneElement"/>
-			</type>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ActiveParticipant"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Participants"/>
@@ -232,29 +144,16 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.role">
 			<path value="AuditEvent.agent.role"/>
-			<short value="Agent role in the event"/>
-			<definition value="The security role that the user was acting under, that come from local codes defined by
-       the access control security system (e.g. RBAC, ABAC) used in the local context."/>
-			<comment value="Should be roles relevant to the event. Should  not be an exhaustive list of roles."/>
-			<requirements value="This value ties an audited event to a user's role(s). It is an optional value that might
-       be used to group events for analysis by user functional role categories."/>
 			<min value="1"/>
 			<max value="1"/>
-			<type>
-				<code value="CodeableConcept"/>
-			</type>
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
 				</extension>
 				<strength value="required"/>
-				<description value="EprParticipant"/>
+				<description value="EPR Participant"/>
 				<valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"/>
 			</binding>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="RoleIdCode"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="role (PAT, HCP, ASS, REP, GRP, TCU, DADM)"/>
@@ -262,13 +161,6 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.who">
 			<path value="AuditEvent.agent.who"/>
-			<short value="Identifier of who"/>
-			<definition value="Reference to who this agent is that was involved in the event."/>
-			<comment value="Where a User ID is available it will go into who.identifier."/>
-			<requirements value="This field ties an audit event to a specific resource or identifier."/>
-			<alias value="userId"/>
-			<min value="0"/>
-			<max value="1"/>
 			<type>
 				<code value="Reference"/>
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
@@ -279,29 +171,14 @@ For example, an activity may be initiated by one user for other users or involve
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
 			</type>
 			<mapping>
-				<identity value="dicom"/>
-				<map value="UserId"/>
-			</mapping>
-			<mapping>
 				<identity value="ch-atc"/>
 				<map value="applicable identifier"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.name">
 			<path value="AuditEvent.agent.name"/>
-			<short value="Human-meaningful name for the agent"/>
 			<definition value="AttributeStatement/Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject- id']/AttributeValue"/>
-			<requirements value="The User ID and Authorization User ID may be internal or otherwise obscure values. This
-       field assists the auditor in identifying the actual user."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="UserName"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Name"/>
@@ -309,35 +186,12 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.requestor">
 			<path value="AuditEvent.agent.requestor"/>
-			<short value="Whether user is initiator"/>
-			<definition value="Indicator that the participant is the initiator for the event being audited."/>
-			<comment value="There can only be one initiator. If the initiator is not clear, then do not choose any
-       one agent as the initiator."/>
-			<requirements value="This value is used to distinguish between requestor-users and recipient-users. For example,
-       one person may initiate a report-output to be sent to another user."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="boolean"/>
-			</type>
-
-			<mapping>
-				<identity value="rim"/>
-				<map value="If participation.typeCode was author, then true"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="UserIsRequestor"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="who"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="if participant is Initiator"/>
 			</mapping>
 		</element>
+		
 		<element id="AuditEvent.entity">
 			<path value="AuditEvent.entity"/>
 			<slicing>
@@ -351,46 +205,8 @@ For example, an activity may be initiated by one user for other users or involve
 				</discriminator>
 				<rules value="open"/>
 			</slicing>
-			<short value="Data or objects used"/>
-			<definition value="Specific instances of data or objects that have been accessed."/>
-			<comment value="Required unless the values for event identification, agent identification, and audit source
-       identification are sufficient to document the entire auditable event. Because events may
-       have more than one entity, this group can be a repeating set of values."/>
-			<requirements value="The event may have other entities involved."/>
-			<alias value="ParticipantObject"/>
-			<min value="0"/>
-			<max value="*"/>
-			<type>
-				<code value="BackboneElement"/>
-			</type>
-			<constraint>
-				<key value="sev-1"/>
-				<severity value="error"/>
-				<human value="Either a name or a query (NOT both)"/>
-				<expression value="name.empty() or query.empty()"/>
-				<xpath value="not(exists(f:name)) or not(exists(f:query))"/>
-			</constraint>
-			<mapping>
-				<identity value="w5"/>
-				<map value="FiveWs.what[x]"/>
-			</mapping>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".outboundRelationship[typeCode=SUBJ].target  or .participation[typeCode=SBJ].role"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectIdentification"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Entity"/>
-			</mapping>
-			<mapping>
-				<identity value="fhirprovenance"/>
-				<map value="Provenance.target, Provenance.entity"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Patient -->
 		<element id="AuditEvent.entity:Patient">
 			<path value="AuditEvent.entity"/>
@@ -398,77 +214,48 @@ For example, an activity may be initiated by one user for other users or involve
 			<short value="Patient" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Patient"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Patient">
+		<element id="AuditEvent.entity:Patient.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
 			<short value="Patient Id (EPR-SPID)" />
-			<definition value="Patient Id (EPR-SPID)"/>
-			<comment value="."/>
 			<min value="1"/>
 			<max value="1"/>
 			<type>
 				<code value="Identifier"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectID and ParticipantObjectIDTypeCode"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="EPR-SPID"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier.system:Patient">
+		<element id="AuditEvent.entity:Patient.what.identifier.system">
 			<path value="AuditEvent.entity.what.identifier.system"/>
 			<min value="1"/>
 			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.3"/>
 		</element>
-		<element id="AuditEvent.entity.type:Patient">
+		<element id="AuditEvent.entity:Patient.type">
 			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.type.code:Patient">
+		<element id="AuditEvent.entity:Patient.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
 			<fixedCode value="1"/>
-
 		</element>
-		<element id="AuditEvent.entity.role:Patient">
+		<element id="AuditEvent.entity:Patient.role">
 			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.role.code:Patient">
+		<element id="AuditEvent.entity:Patient.role.code">
 			<path value="AuditEvent.entity.role.code"/>
 			<min value="1"/>
 			<fixedCode value="1"/>
-
 		</element>
+
 		<!-- Slice Document -->
 		<element id="AuditEvent.entity:Document">
 			<path value="AuditEvent.entity"/>
@@ -476,69 +263,43 @@ For example, an activity may be initiated by one user for other users or involve
 			<short value="Document" />
 			<min value="0"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Document"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Document">
+		<element id="AuditEvent.entity:Document.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
 			<short value="XDSDocumentEntry.uniqueId" />
-			<definition value="XDSDocumentEntry.uniqueId"/>
-			<comment value="."/>
 			<min value="1"/>
 			<max value="1"/>
 			<type>
 				<code value="Identifier"/>
 			</type>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="uniqueId"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.type:Document">
+		<element id="AuditEvent.entity:Document.type">
 			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.type.code:Document">
+		<element id="AuditEvent.entity:Document.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
 			<fixedCode value="2"/>
-
 		</element>
-		<element id="AuditEvent.entity.role:Document">
+		<element id="AuditEvent.entity:Document.role">
 			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.role.code:Document">
+		<element id="AuditEvent.entity:Document.role.code">
 			<path value="AuditEvent.entity.role.code"/>
 			<min value="1"/>
 			<fixedCode value="3"/>
-
 		</element>
-		<element id="AuditEvent.entity.detail:Document">
+		<element id="AuditEvent.entity:Document.detail">
 			<path value="AuditEvent.entity.detail"/>
 			<slicing>
 				<discriminator>
@@ -547,178 +308,107 @@ For example, an activity may be initiated by one user for other users or involve
 				</discriminator>
 				<rules value="open"/>
 			</slicing>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Document Detail: repositoryUniqueId  -->
-		<element id="AuditEvent.entity.detail:Document:repositoryUniqueId">
+		<element id="AuditEvent.entity:Document.detail:repositoryUniqueId">
 			<path value="AuditEvent.entity.detail"/>
 			<sliceName value="repositoryUniqueId"/>
 			<short value="repositoryUniqueId" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="repositoryUniqueId"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail.type:Document:repositoryUniqueId">
+		<element id="AuditEvent.entity:Document.detail.type:repositoryUniqueId">
 			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
 			<fixedString value="Repository Unique Id"/>
-
 		</element>
 		<element id="AuditEvent.entity.detail.value:repositoryUniqueId">
 			<path value="AuditEvent.entity.detail.value"/>
-			<short value="Property value"/>
 			<definition value="The details, base64 encoded. Used to carry bulk information."/>
 			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
 			<type>
 				<code value="base64Binary"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Document Detail: homeCommunityID  -->
-		<element id="AuditEvent.entity.detail:Document:homeCommunityID">
+		<element id="AuditEvent.entity:Document.detail:homeCommunityID">
 			<path value="AuditEvent.entity.detail"/>
 			<sliceName value="homeCommunityID"/>
 			<short value="homeCommunityID" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="homeCommunityID"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail.type:Document:homeCommunityID">
+		<element id="AuditEvent.entity:Document.detail.type:homeCommunityID">
 			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
 			<fixedString value="homeCommunityID"/>
-
 		</element>
 		<element id="AuditEvent.entity.detail.value:homeCommunityID">
 			<path value="AuditEvent.entity.detail.value"/>
-			<short value="Property value"/>
 			<definition value="The details, base64 encoded. Used to carry bulk information."/>
 			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
 			<type>
 				<code value="base64Binary"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Document Detail: EprDocumentTypeCode  -->
-		<element id="AuditEvent.entity.detail:Document:EprDocumentTypeCode">
+		<element id="AuditEvent.entity:Document.detail:EprDocumentTypeCode">
 			<path value="AuditEvent.entity.detail"/>
 			<sliceName value="EprDocumentTypeCode"/>
 			<short value="EprDocumentTypeCode" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="typeCode"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail.type:Document:EprDocumentTypeCode">
+		<element id="AuditEvent.entity:Document.detail.type:EprDocumentTypeCode">
 			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
 			<fixedString value="EprDocumentTypeCode"/>
-
 		</element>
 		<element id="AuditEvent.entity.detail.value:EprDocumentTypeCode">
 			<path value="AuditEvent.entity.detail.value"/>
-			<short value="Property value"/>
 			<definition value="The details, base64 encoded. Used to carry bulk information."/>
 			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
 			<type>
 				<code value="base64Binary"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
 		</element>
 		<!-- Slice Document Detail: title  -->
-		<element id="AuditEvent.entity.detail:Document:title">
+		<element id="AuditEvent.entity:Document.detail:title">
 			<path value="AuditEvent.entity.detail"/>
 			<sliceName value="title"/>
 			<short value="title" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="title"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail.type:Document:title">
+		<element id="AuditEvent.entity:Document.detail.type:title">
 			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
 			<fixedString value="title"/>
 		</element>
 		<element id="AuditEvent.entity.detail.value:title">
 			<path value="AuditEvent.entity.detail.value"/>
-			<short value="Property value"/>
 			<definition value="The details, base64 encoded. Used to carry bulk information."/>
 			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
 			<type>
 				<code value="base64Binary"/>
 			</type>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Query -->
 		<element id="AuditEvent.entity:Query">
 			<path value="AuditEvent.entity"/>
@@ -726,63 +416,38 @@ For example, an activity may be initiated by one user for other users or involve
 			<short value="Query" />
 			<min value="0"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Query"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Query">
+		<element id="AuditEvent.entity:Query.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
 			<short value="XDSQueryEntry.uniqueId" />
-			<definition value="XDSQueryEntry.uniqueId"/>
-			<comment value="."/>
 			<min value="1"/>
 			<max value="1"/>
 			<type>
 				<code value="Identifier"/>
 			</type>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="patient EPRSPID"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.type:Query">
+		<element id="AuditEvent.entity:Query.type">
 			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.type.code:Query">
+		<element id="AuditEvent.entity:Query.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
 			<fixedCode value="2"/>
-
 		</element>
-		<element id="AuditEvent.entity.role:Query">
+		<element id="AuditEvent.entity:Query.role">
 			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.role.code:Query">
+		<element id="AuditEvent.entity:Query.role.code">
 			<path value="AuditEvent.entity.role.code"/>
 			<min value="1"/>
 			<fixedCode value="24"/>

--- a/input/resources/structuredefinition/DocumentAuditEvent.xml
+++ b/input/resources/structuredefinition/DocumentAuditEvent.xml
@@ -159,16 +159,12 @@
 				<map value="role (PAT, HCP, ASS, REP, GRP, TCU, DADM)"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.agent.who">
-			<path value="AuditEvent.agent.who"/>
+		<element id="AuditEvent.agent.who.identifier">
+			<path value="AuditEvent.agent.who.identifier"/>
+			<min value="1"/>
+			<max value="1"/>
 			<type>
-				<code value="Reference"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
+				<code value="Identifier"/>
 			</type>
 			<mapping>
 				<identity value="ch-atc"/>
@@ -191,7 +187,7 @@
 				<map value="if participant is Initiator"/>
 			</mapping>
 		</element>
-		
+
 		<element id="AuditEvent.entity">
 			<path value="AuditEvent.entity"/>
 			<slicing>

--- a/input/resources/structuredefinition/DocumentAuditEvent.xml
+++ b/input/resources/structuredefinition/DocumentAuditEvent.xml
@@ -679,6 +679,46 @@ For example, an activity may be initiated by one user for other users or involve
 				<map value="ParticipantObjectDetail.value"/>
 			</mapping>
 		</element>
+		<!-- Slice Document Detail: title  -->
+		<element id="AuditEvent.entity.detail:Document:title">
+			<path value="AuditEvent.entity.detail"/>
+			<sliceName value="title"/>
+			<short value="title" />
+			<min value="1"/>
+			<max value="1"/>
+
+			<mapping>
+				<identity value="ch-atc"/>
+				<map value="title"/>
+			</mapping>
+		</element>
+		<element id="AuditEvent.entity.detail.type:Document:title">
+			<path value="AuditEvent.entity.detail.type"/>
+			<short value="Name of the property"/>
+			<definition value="The type of extra detail provided in the value."/>
+			<min value="1"/>
+			<max value="1"/>
+			<type>
+				<code value="string"/>
+			</type>
+			<fixedString value="title"/>
+		</element>
+		<element id="AuditEvent.entity.detail.value:title">
+			<path value="AuditEvent.entity.detail.value"/>
+			<short value="Property value"/>
+			<definition value="The details, base64 encoded. Used to carry bulk information."/>
+			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
+			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
+			<min value="1"/>
+			<max value="1"/>
+			<type>
+				<code value="base64Binary"/>
+			</type>
+			<mapping>
+				<identity value="dicom"/>
+				<map value="ParticipantObjectDetail.value"/>
+			</mapping>
+		</element>
 		<!-- Slice Query -->
 		<element id="AuditEvent.entity:Query">
 			<path value="AuditEvent.entity"/>

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -28,7 +28,7 @@
 			<value value="oliver.egger@ahdis.ch"/>
 		</telecom>
 	</contact>
-	<description value="This profile defines the content of the HPD audit events which a community has to provide for a patients audit trail. " />
+	<description value="This profile defines the content of the HPD audit events which a community has to provide for a patients audit trail." />
 	<jurisdiction>
 		<coding>
 			<system value="urn:iso:std:iso:3166"/>
@@ -42,11 +42,6 @@
 		<uri value="https://www.bag.admin.ch/bag/en/home.html" />
 		<name value="Mapping to CH ATC" />
 	</mapping>
-	<mapping>
-		<identity value="dicom"/>
-		<uri value="http://nema.org/dicom"/>
-		<name value="DICOM Tag Mapping"/>
-	</mapping>
 	<kind value="resource" />
 	<abstract value="false" />
 	<type value="AuditEvent" />
@@ -56,35 +51,17 @@
 		<element id="AuditEvent">
 			<path value="AuditEvent"/>
 			<short value="HPD Audit Trail Content Profile"/>
-			<definition value="HPD Audit Trail Content Profil"/>
-			<comment value="Based on ATNA (RFC 3881)."/>
-			<min value="0"/>
-			<max value="*"/>
 			<constraint>
 				<key value="ch-atc-pae-1"/>
 				<severity value="error"/>
 				<human value="subtype needs to be fixed to ValueSet HpdAuditEventType"/>
-				<!--				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/HpdAuditEventType')"/>  member of not implemented yet -->
+				<!-- <expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/HpdAuditEventType')"/>  member of not implemented yet -->
 				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].code.startsWith('ATC_HPD')"/>
 			</constraint>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="Message"/>
-			</mapping>
 		</element>
+
 		<element id="AuditEvent.type">
 			<path value="AuditEvent.type"/>
-			<short value="Type/identifier of event"/>
-			<definition value="Identifier for a family of the event.  For example, a menu item, program, rule, HPD,
-       function code, application name or URL. It identifies the performed function."/>
-			<requirements value="This identifies the performed function. For &quot;Execute&quot; Event Action Code audit
-       records, this identifies the application function performed."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="AuditEventType"/>
@@ -94,6 +71,7 @@
 				<valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"/>
 			</binding>
 		</element>
+
 		<element id="AuditEvent.subtype">
 			<path value="AuditEvent.subtype"/>
 			<slicing>
@@ -104,23 +82,13 @@
 				<rules value="open"/>
 			</slicing>
 			<min value="1"/>
-			<max value="*"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventTypeCode"/>
-			</mapping>
 		</element>
 		<element id="AuditEvent.subtype:HpdAuditEventType">
 			<path value="AuditEvent.subtype"/>
 			<sliceName value="HpdAuditEventType"/>
-			<short value="HpdAuditEventType" />
+			<short value="HPD Audit Event Type" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
@@ -139,46 +107,18 @@
 			<min value="1"/>
 			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
 		</element>
+
 		<element id="AuditEvent.recorded">
 			<path value="AuditEvent.recorded"/>
-			<short value="Time when the event was recorded"/>
-			<definition value="The time when the event was recorded."/>
-			<comment value="In a distributed system, some sort of common time base (e.g. an NTP [RFC1305] server)
-       is a good implementation tactic."/>
-			<requirements value="This ties an event to a specific date and time. Security audits typically require a consistent
-       time base (e.g. UTC), to eliminate time-zone issues arising from geographical distribution."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="instant"/>
-			</type>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Event Date and Time"/>
 			</mapping>
 		</element>
+
 		<element id="AuditEvent.agent">
 			<path value="AuditEvent.agent"/>
 			<short value="Participants"/>
-			<definition value="Participants"/>
-			<comment value="Several agents may be associated (i.e. have some responsibility for an activity) with
-       an event or activity.
-
-For example, an activity may be initiated by one user for other users or involve more
-       than one user. However, only one user may be the initiator/requestor for the activity."/>
-			<requirements value="An agent can be a person, an organization, software, device, or other actors that may
-       be ascribed responsibility."/>
-			<alias value="ActiveParticipant"/>
-			<min value="1"/>
-			<max value="*"/>
-			<type>
-				<code value="BackboneElement"/>
-			</type>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ActiveParticipant"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Participants"/>
@@ -186,28 +126,16 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.role">
 			<path value="AuditEvent.agent.role"/>
-			<short value="Agent role in the event"/>
-			<definition value="The security role that the user was acting under, that come from local codes defined by
-       the access control security system (e.g. RBAC, ABAC) used in the local context."/>
-			<comment value="Should be roles relevant to the event. Should  not be an exhaustive list of roles."/>
-			<requirements value="This value ties an audited event to a user's role(s). It is an optional value that might be used to group events for analysis by user functional role categories."/>
 			<min value="1"/>
 			<max value="1"/>
-			<type>
-				<code value="CodeableConcept"/>
-			</type>
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
 				</extension>
 				<strength value="required"/>
-				<description value="EprParticipant"/>
+				<description value="EPR Participant"/>
 				<valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"/>
 			</binding>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="RoleIdCode"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="role (PAT, HCP, ASS, REP, GRP, PADM)"/>
@@ -215,13 +143,6 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.who">
 			<path value="AuditEvent.agent.who"/>
-			<short value="Identifier of who"/>
-			<definition value="Reference to who this agent is that was involved in the event."/>
-			<comment value="Where a User ID is available it will go into who.identifier."/>
-			<requirements value="This field ties an audit event to a specific resource or identifier."/>
-			<alias value="userId"/>
-			<min value="0"/>
-			<max value="1"/>
 			<type>
 				<code value="Reference"/>
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
@@ -232,30 +153,14 @@ For example, an activity may be initiated by one user for other users or involve
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
 			</type>
 			<mapping>
-				<identity value="dicom"/>
-				<map value="UserId"/>
-			</mapping>
-			<mapping>
 				<identity value="ch-atc"/>
 				<map value="applicable identifier"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.name">
 			<path value="AuditEvent.agent.name"/>
-			<short value="Human-meaningful name for the agent"/>
 			<definition value="AttributeStatement/Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject- id']/AttributeValue"/>
-			<requirements value="The User ID and Authorization User ID may be internal or otherwise obscure values. This
-       field assists the auditor in identifying the actual user."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="UserName"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Name"/>
@@ -263,35 +168,12 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.requestor">
 			<path value="AuditEvent.agent.requestor"/>
-			<short value="Whether user is initiator"/>
-			<definition value="Indicator that the participant is the initiator for the event being audited."/>
-			<comment value="There can only be one initiator. If the initiator is not clear, then do not choose any
-       one agent as the initiator."/>
-			<requirements value="This value is used to distinguish between requestor-users and recipient-users. For example,
-       one person may initiate a report-output to be sent to another user."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="boolean"/>
-			</type>
-
-			<mapping>
-				<identity value="rim"/>
-				<map value="If participation.typeCode was author, then true"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="UserIsRequestor"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="who"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="if participant is Initiator"/>
 			</mapping>
 		</element>
+
 		<element id="AuditEvent.entity">
 			<path value="AuditEvent.entity"/>
 			<slicing>
@@ -301,46 +183,8 @@ For example, an activity may be initiated by one user for other users or involve
 				</discriminator>
 				<rules value="open"/>
 			</slicing>
-			<short value="Data or objects used"/>
-			<definition value="Specific instances of data or objects that have been accessed."/>
-			<comment value="Required unless the values for event identification, agent identification, and audit source
-       identification are sufficient to document the entire auditable event. Because events may
-       have more than one entity, this group can be a repeating set of values."/>
-			<requirements value="The event may have other entities involved."/>
-			<alias value="ParticipantObject"/>
-			<min value="0"/>
-			<max value="*"/>
-			<type>
-				<code value="BackboneElement"/>
-			</type>
-			<constraint>
-				<key value="sev-1"/>
-				<severity value="error"/>
-				<human value="Either a name or a query (NOT both)"/>
-				<expression value="name.empty() or query.empty()"/>
-				<xpath value="not(exists(f:name)) or not(exists(f:query))"/>
-			</constraint>
-			<mapping>
-				<identity value="w5"/>
-				<map value="FiveWs.what[x]"/>
-			</mapping>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".outboundRelationship[typeCode=SUBJ].target  or .participation[typeCode=SBJ].role"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectIdentification"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Entity"/>
-			</mapping>
-			<mapping>
-				<identity value="fhirprovenance"/>
-				<map value="Provenance.target, Provenance.entity"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Patient -->
 		<element id="AuditEvent.entity:Patient">
 			<path value="AuditEvent.entity"/>
@@ -348,77 +192,44 @@ For example, an activity may be initiated by one user for other users or involve
 			<short value="Patient" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Patient"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Patient">
+		<element id="AuditEvent.entity:Patient.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
 			<short value="Patient Id (EPR-SPID)" />
-			<definition value="Patient Id (EPR-SPID)"/>
-			<comment value="."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Identifier"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectID and ParticipantObjectIDTypeCode"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="EPR-SPID"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier.system:Patient">
+		<element id="AuditEvent.entity:Patient.what.identifier.system">
 			<path value="AuditEvent.entity.what.identifier.system"/>
 			<min value="1"/>
 			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.3"/>
 		</element>
-		<element id="AuditEvent.entity.type:Patient">
+		<element id="AuditEvent.entity:Patient.type">
 			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.type.code:Patient">
+		<element id="AuditEvent.entity:Patient.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
 			<fixedCode value="1"/>
-
 		</element>
-		<element id="AuditEvent.entity.role:Patient">
+		<element id="AuditEvent.entity:Patient.role">
 			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.role.code:Patient">
+		<element id="AuditEvent.entity:Patient.role.code">
 			<path value="AuditEvent.entity.role.code"/>
 			<min value="1"/>
 			<fixedCode value="1"/>
-
 		</element>
+
 		<!-- Slice  Resource -->
 		<element id="AuditEvent.entity:Group">
 			<path value="AuditEvent.entity"/>
@@ -426,92 +237,42 @@ For example, an activity may be initiated by one user for other users or involve
 			<short value="Group" />
 			<min value="0"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Group"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Group">
+		<element id="AuditEvent.entity:Group.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
 			<short value="Identifier for Group (OID)" />
 			<definition value="Identifier for Group (OID)"/>
-			<min value="0"/>
 			<max value="1"/>
-			<type>
-				<code value="Identifier"/>
-			</type>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Identifier for Group (OID)"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.type:Group">
+		<element id="AuditEvent.entity:Group.type">
 			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
 		</element>
-		<element id="AuditEvent.entity.type.code:Group">
+		<element id="AuditEvent.entity:Group.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
 			<fixedCode value="3"/>
 		</element>
-		<element id="AuditEvent.entity.role:Group">
+		<element id="AuditEvent.entity:Group.role">
 			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
 			<fixedCoding>
 				<system value= "urn:oid:2.16.756.5.30.1.127.3.10.14" />
 				<code value="GRP" />
 			</fixedCoding>
 		</element>
-		<element id="AuditEvent.entity.name:Group">
+		<element id="AuditEvent.entity:Group.name">
 			<path value="AuditEvent.entity.name"/>
 			<short value="Group name"/>
-			<definition value="A name of the entity in the audit event."/>
-			<comment value="This field may be used in a query/report to identify audit events for a specific person.
-        For example, where multiple synonymous entity identifiers (patient number, medical record
-       number, encounter number, etc.) have been used."/>
-			<requirements value="Use only where entity can't be identified with an identifier."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-			<condition value="sev-1"/>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".title"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectName"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Entity.Label"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="context"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Name of Group"/>

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -122,7 +122,7 @@
 			<max value="1"/>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="Participants"/>
+				<map value="Notification service"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.who.identifier">
@@ -150,7 +150,7 @@
 			<path value="AuditEvent.agent.requestor"/>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="if participant is Initiator"/>
+				<map value="if notification service is Initiator"/>
 			</mapping>
 		</element>
 

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -118,7 +118,7 @@
 
 		<element id="AuditEvent.agent">
 			<path value="AuditEvent.agent"/>
-			<short value="Participants"/>
+			<short value="Notification service"/>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Participants"/>
@@ -126,6 +126,7 @@
 		</element>
 		<element id="AuditEvent.agent.role">
 			<path value="AuditEvent.agent.role"/>
+			<short value="Policy Administrator (PADM)"/>
 			<min value="1"/>
 			<max value="1"/>
 			<binding>
@@ -138,7 +139,7 @@
 			</binding>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="role (PAT, HCP, ASS, REP, GRP, PADM)"/>
+				<map value="role (PADM)"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.who">
@@ -159,11 +160,11 @@
 		</element>
 		<element id="AuditEvent.agent.name">
 			<path value="AuditEvent.agent.name"/>
-			<definition value="AttributeStatement/Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject- id']/AttributeValue"/>
+			<short value="Name of notification service"/>
 			<min value="1"/>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="Name"/>
+				<map value="Name of Notification Service"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.requestor">
@@ -230,7 +231,68 @@
 			<fixedCode value="1"/>
 		</element>
 
-		<!-- Slice  Resource -->
+		<!-- Slice Healthcare professional -->
+		<element id="AuditEvent.entity:HealthcareProfessional">
+			<path value="AuditEvent.entity"/>
+			<sliceName value="HealthcareProfessional"/>
+			<short value="Healthcare professional (HCP)" />
+			<min value="1"/>
+			<max value="*"/>
+			<mapping>
+				<identity value="ch-atc"/>
+				<map value="Healthcare professional"/>
+			</mapping>
+		</element>
+		<element id="AuditEvent.entity:HealthcareProfessional.what.identifier">
+			<path value="AuditEvent.entity.what.identifier"/>
+			<short value="Identifier: HCP (GLN)" />
+			<min value="1"/>
+			<mapping>
+				<identity value="ch-atc"/>
+				<map value="Identifier for HCP (GLN)"/>
+			</mapping>
+		</element>
+		<element id="AuditEvent.entity:HealthcareProfessional.what.identifier.system">
+			<path value="AuditEvent.entity.what.identifier.system"/>
+			<min value="1"/>
+			<fixedUri value="urn:oid:2.51.1.3"/>
+		</element>
+		<element id="AuditEvent.entity:HealthcareProfessional.type">
+			<path value="AuditEvent.entity.type"/>
+			<min value="1"/>
+		</element>
+		<element id="AuditEvent.entity:HealthcareProfessional.type.code">
+			<path value="AuditEvent.entity.type.code"/>
+			<min value="1"/>
+			<fixedCode value="2"/>
+		</element>
+
+		<element id="AuditEvent.entity:HealthcareProfessional.role">
+			<path value="AuditEvent.entity.role"/>
+			<min value="1"/>
+		</element>
+		<element id="AuditEvent.entity:HealthcareProfessional.role.system">
+			<path value="AuditEvent.entity.role.system"/>
+			<min value="1"/>
+			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.6"/>
+		</element>
+		<element id="AuditEvent.entity:HealthcareProfessional.role.code">
+			<path value="AuditEvent.entity.role.code"/>
+			<min value="1"/>
+			<fixedCode value="HCP" />
+		</element>
+
+		<element id="AuditEvent.entity:HealthcareProfessional.name">
+			<path value="AuditEvent.entity.name"/>
+			<short value="Healthcare professional name"/>
+			<min value="1"/>
+			<mapping>
+				<identity value="ch-atc"/>
+				<map value="Name of Healthcare Professional"/>
+			</mapping>
+		</element>
+
+		<!-- Slice Group -->
 		<element id="AuditEvent.entity:Group">
 			<path value="AuditEvent.entity"/>
 			<sliceName value="Group"/>
@@ -261,14 +323,22 @@
 			<min value="1"/>
 			<fixedCode value="3"/>
 		</element>
+
 		<element id="AuditEvent.entity:Group.role">
 			<path value="AuditEvent.entity.role"/>
 			<min value="1"/>
-			<fixedCoding>
-				<system value= "urn:oid:2.16.756.5.30.1.127.3.10.14" />
-				<code value="GRP" />
-			</fixedCoding>
 		</element>
+		<element id="AuditEvent.entity:Group.role.system">
+			<path value="AuditEvent.entity.role.system"/>
+			<min value="1"/>
+			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.14"/>
+		</element>
+		<element id="AuditEvent.entity:Group.role.code">
+			<path value="AuditEvent.entity.role.code"/>
+			<min value="1"/>
+			<fixedCode value="GRP" />
+		</element>
+
 		<element id="AuditEvent.entity:Group.name">
 			<path value="AuditEvent.entity.name"/>
 			<short value="Group name"/>

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -142,16 +142,12 @@
 				<map value="role (PADM)"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.agent.who">
-			<path value="AuditEvent.agent.who"/>
+		<element id="AuditEvent.agent.who.identifier">
+			<path value="AuditEvent.agent.who.identifier"/>
+			<min value="1"/>
+			<max value="1"/>
 			<type>
-				<code value="Reference"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
+				<code value="Identifier"/>
 			</type>
 			<mapping>
 				<identity value="ch-atc"/>

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
-	<id value="DocumentAuditEvent" />
+	<id value="HpdAuditEvent" />
 	<text>
 		<status value="additional" />
 		<div xmlns="http://www.w3.org/1999/xhtml">
-	StructureDefinition for the DocumentAuditEvent.
+	StructureDefinition for the HpdAuditEvent.
 		</div>
 	</text>
-	<url value="http://fhir.ch/ig/ch-atc/StructureDefinition/DocumentAuditEvent" />
-	<name value="DocumentAuditEvent" />
-	<title value="DocumentAuditEvent" />
+	<url value="http://fhir.ch/ig/ch-atc/StructureDefinition/HpdAuditEvent" />
+	<name value="HpdAuditEvent" />
+	<title value="HpdAuditEvent" />
 	<status value="active" />
 	<experimental value="false" />
 	<date value="2018-05-28" />
@@ -28,7 +28,7 @@
 			<value value="oliver.egger@ahdis.ch"/>
 		</telecom>
 	</contact>
-	<description value="This profile defines the content of the document audit events which a community has to provide for a patients audit trail. " />
+	<description value="This profile defines the content of the HPD audit events which a community has to provide for a patients audit trail. " />
 	<jurisdiction>
 		<coding>
 			<system value="urn:iso:std:iso:3166"/>
@@ -55,17 +55,17 @@
 	<differential>
 		<element id="AuditEvent">
 			<path value="AuditEvent"/>
-			<short value="Document Audit Trail Content Profile"/>
-			<definition value="Document Audit Trail Content Profil"/>
+			<short value="HPD Audit Trail Content Profile"/>
+			<definition value="HPD Audit Trail Content Profil"/>
 			<comment value="Based on ATNA (RFC 3881)."/>
 			<min value="0"/>
 			<max value="*"/>
 			<constraint>
-				<key value="ch-atc-dae-1"/>
+				<key value="ch-atc-pae-1"/>
 				<severity value="error"/>
-				<human value="subtype needs to be fixed to ValueSet DocumentAuditEventType"/>
-				<!--				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/DocumentAuditEventType')"/>  member of not implemented yet -->
-				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].code.startsWith('ATC_DOC')"/>
+				<human value="subtype needs to be fixed to ValueSet HpdAuditEventType"/>
+				<!--				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/HpdAuditEventType')"/>  member of not implemented yet -->
+				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].code.startsWith('ATC_HPD')"/>
 			</constraint>
 			<mapping>
 				<identity value="dicom"/>
@@ -75,7 +75,7 @@
 		<element id="AuditEvent.type">
 			<path value="AuditEvent.type"/>
 			<short value="Type/identifier of event"/>
-			<definition value="Identifier for a family of the event.  For example, a menu item, program, rule, policy,
+			<definition value="Identifier for a family of the event.  For example, a menu item, program, rule, HPD,
        function code, application name or URL. It identifies the performed function."/>
 			<requirements value="This identifies the performed function. For &quot;Execute&quot; Event Action Code audit
        records, this identifies the application function performed."/>
@@ -93,22 +93,6 @@
 				<description value="Type of event."/>
 				<valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"/>
 			</binding>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".code (type, subtype and action are pre-coordinated or sent as translations)"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventId"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Activity"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="what"/>
-			</mapping>
 		</element>
 		<element id="AuditEvent.subtype">
 			<path value="AuditEvent.subtype"/>
@@ -130,10 +114,10 @@
 				<map value="EventTypeCode"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.subtype:DocumentAuditEventType">
+		<element id="AuditEvent.subtype:HpdAuditEventType">
 			<path value="AuditEvent.subtype"/>
-			<sliceName value="DocumentAuditEventType"/>
-			<short value="DocumentAuditEventType" />
+			<sliceName value="HpdAuditEventType"/>
+			<short value="HpdAuditEventType" />
 			<min value="1"/>
 			<max value="1"/>
 
@@ -142,15 +126,15 @@
 					<valueString value="ConditionKind"/>
 				</extension>
 				<strength value="required"/>
-				<description value="Document Audit Event Type"/>
-				<valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/DocumentAuditEventType"/>
+				<description value="HPD Audit Event Type"/>
+				<valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/HpdAuditEventType"/>
 			</binding>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Event Type"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.subtype.system:DocumentAuditEventType">
+		<element id="AuditEvent.subtype.system:HpdAuditEventType">
 			<path value="AuditEvent.subtype.system"/>
 			<min value="1"/>
 			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
@@ -172,36 +156,6 @@
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Event Date and Time"/>
-			</mapping>
-		</element>
-		<element id="AuditEvent.purposeOfEvent">
-			<path value="AuditEvent.purposeOfEvent"/>
-			<short value="The purposeOfUse of the event"/>
-			<definition value="The purposeOfUse (reason) that was used during the event being recorded."/>
-			<comment value="Use AuditEvent.agent.purposeOfUse when you know that it is specific to the agent, otherwise
-       use AuditEvent.purposeOfEvent. For example, during a machine-to-machine transfer it might
-       not be obvious to the audit system who caused the event, but it does know why."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="CodeableConcept"/>
-			</type>
-
-			<binding>
-				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-					<valueString value="ConditionKind"/>
-				</extension>
-				<strength value="required"/>
-				<description value="EprPurposeOfUse"/>
-				<valueSet value="http://fhir.ch/ig/ch-epr-term/ValueSet/EprPurposeOfUse"/>
-			</binding>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventPurposeOfUse"/>
-			</mapping>
-			<mapping>
-				<identity value="ch-atc"/>
-				<map value="PurposeOfUse"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent">
@@ -236,8 +190,7 @@ For example, an activity may be initiated by one user for other users or involve
 			<definition value="The security role that the user was acting under, that come from local codes defined by
        the access control security system (e.g. RBAC, ABAC) used in the local context."/>
 			<comment value="Should be roles relevant to the event. Should  not be an exhaustive list of roles."/>
-			<requirements value="This value ties an audited event to a user's role(s). It is an optional value that might
-       be used to group events for analysis by user functional role categories."/>
+			<requirements value="This value ties an audited event to a user's role(s). It is an optional value that might be used to group events for analysis by user functional role categories."/>
 			<min value="1"/>
 			<max value="1"/>
 			<type>
@@ -257,7 +210,7 @@ For example, an activity may be initiated by one user for other users or involve
 			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="role (PAT, HCP, ASS, REP, GRP, TCU, DADM)"/>
+				<map value="role (PAT, HCP, ASS, REP, GRP, PADM)"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.who">
@@ -298,6 +251,7 @@ For example, an activity may be initiated by one user for other users or involve
 			<type>
 				<code value="string"/>
 			</type>
+
 			<mapping>
 				<identity value="dicom"/>
 				<map value="UserName"/>
@@ -344,10 +298,6 @@ For example, an activity may be initiated by one user for other users or involve
 				<discriminator>
 					<type value="value" />
 					<path value="type.code" />
-				</discriminator>
-				<discriminator>
-					<type value="value" />
-					<path value="role.code" />
 				</discriminator>
 				<rules value="open"/>
 			</slicing>
@@ -469,25 +419,24 @@ For example, an activity may be initiated by one user for other users or involve
 			<fixedCode value="1"/>
 
 		</element>
-		<!-- Slice Document -->
-		<element id="AuditEvent.entity:Document">
+		<!-- Slice  Resource -->
+		<element id="AuditEvent.entity:Group">
 			<path value="AuditEvent.entity"/>
-			<sliceName value="Document"/>
-			<short value="Document" />
+			<sliceName value="Group"/>
+			<short value="Group" />
 			<min value="0"/>
 			<max value="1"/>
 
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="Document"/>
+				<map value="Group"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Document">
+		<element id="AuditEvent.entity.what.identifier:Group">
 			<path value="AuditEvent.entity.what.identifier"/>
-			<short value="XDSDocumentEntry.uniqueId" />
-			<definition value="XDSDocumentEntry.uniqueId"/>
-			<comment value="."/>
-			<min value="1"/>
+			<short value="Identifier for Group (OID)" />
+			<definition value="Identifier for Group (OID)"/>
+			<min value="0"/>
 			<max value="1"/>
 			<type>
 				<code value="Identifier"/>
@@ -495,10 +444,10 @@ For example, an activity may be initiated by one user for other users or involve
 
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="uniqueId"/>
+				<map value="Identifier for Group (OID)"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.type:Document">
+		<element id="AuditEvent.entity.type:Group">
 			<path value="AuditEvent.entity.type"/>
 			<short value="Type of entity involved"/>
 			<definition value="The type of the object that was involved in this audit event."/>
@@ -511,225 +460,13 @@ For example, an activity may be initiated by one user for other users or involve
 			<type>
 				<code value="Coding"/>
 			</type>
-
 		</element>
-		<element id="AuditEvent.entity.type.code:Document">
+		<element id="AuditEvent.entity.type.code:Group">
 			<path value="AuditEvent.entity.type.code"/>
-			<min value="1"/>
-			<fixedCode value="2"/>
-
-		</element>
-		<element id="AuditEvent.entity.role:Document">
-			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
-		</element>
-		<element id="AuditEvent.entity.role.code:Document">
-			<path value="AuditEvent.entity.role.code"/>
 			<min value="1"/>
 			<fixedCode value="3"/>
-
 		</element>
-		<element id="AuditEvent.entity.detail:Document">
-			<path value="AuditEvent.entity.detail"/>
-			<slicing>
-				<discriminator>
-					<type value="value" />
-					<path value="type" />
-				</discriminator>
-				<rules value="open"/>
-			</slicing>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail"/>
-			</mapping>
-		</element>
-		<!-- Slice Document Detail: repositoryUniqueId  -->
-		<element id="AuditEvent.entity.detail:Document:repositoryUniqueId">
-			<path value="AuditEvent.entity.detail"/>
-			<sliceName value="repositoryUniqueId"/>
-			<short value="repositoryUniqueId" />
-			<min value="1"/>
-			<max value="1"/>
-
-			<mapping>
-				<identity value="ch-atc"/>
-				<map value="repositoryUniqueId"/>
-			</mapping>
-		</element>
-		<element id="AuditEvent.entity.detail.type:Document:repositoryUniqueId">
-			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-			<fixedString value="Repository Unique Id"/>
-
-		</element>
-		<element id="AuditEvent.entity.detail.value:repositoryUniqueId">
-			<path value="AuditEvent.entity.detail.value"/>
-			<short value="Property value"/>
-			<definition value="The details, base64 encoded. Used to carry bulk information."/>
-			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="base64Binary"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
-		</element>
-		<!-- Slice Document Detail: homeCommunityID  -->
-		<element id="AuditEvent.entity.detail:Document:homeCommunityID">
-			<path value="AuditEvent.entity.detail"/>
-			<sliceName value="homeCommunityID"/>
-			<short value="homeCommunityID" />
-			<min value="1"/>
-			<max value="1"/>
-
-			<mapping>
-				<identity value="ch-atc"/>
-				<map value="homeCommunityID"/>
-			</mapping>
-		</element>
-		<element id="AuditEvent.entity.detail.type:Document:homeCommunityID">
-			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-			<fixedString value="homeCommunityID"/>
-
-		</element>
-		<element id="AuditEvent.entity.detail.value:homeCommunityID">
-			<path value="AuditEvent.entity.detail.value"/>
-			<short value="Property value"/>
-			<definition value="The details, base64 encoded. Used to carry bulk information."/>
-			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="base64Binary"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
-		</element>
-		<!-- Slice Document Detail: EprDocumentTypeCode  -->
-		<element id="AuditEvent.entity.detail:Document:EprDocumentTypeCode">
-			<path value="AuditEvent.entity.detail"/>
-			<sliceName value="EprDocumentTypeCode"/>
-			<short value="EprDocumentTypeCode" />
-			<min value="1"/>
-			<max value="1"/>
-
-			<mapping>
-				<identity value="ch-atc"/>
-				<map value="typeCode"/>
-			</mapping>
-		</element>
-		<element id="AuditEvent.entity.detail.type:Document:EprDocumentTypeCode">
-			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-			<fixedString value="EprDocumentTypeCode"/>
-
-		</element>
-		<element id="AuditEvent.entity.detail.value:EprDocumentTypeCode">
-			<path value="AuditEvent.entity.detail.value"/>
-			<short value="Property value"/>
-			<definition value="The details, base64 encoded. Used to carry bulk information."/>
-			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="base64Binary"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
-		</element>
-		<!-- Slice Query -->
-		<element id="AuditEvent.entity:Query">
-			<path value="AuditEvent.entity"/>
-			<sliceName value="Query"/>
-			<short value="Query" />
-			<min value="0"/>
-			<max value="1"/>
-
-			<mapping>
-				<identity value="ch-atc"/>
-				<map value="Query"/>
-			</mapping>
-		</element>
-		<element id="AuditEvent.entity.what.identifier:Query">
-			<path value="AuditEvent.entity.what.identifier"/>
-			<short value="XDSQueryEntry.uniqueId" />
-			<definition value="XDSQueryEntry.uniqueId"/>
-			<comment value="."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Identifier"/>
-			</type>
-
-			<mapping>
-				<identity value="ch-atc"/>
-				<map value="patient EPRSPID"/>
-			</mapping>
-		</element>
-		<element id="AuditEvent.entity.type:Query">
-			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
-		</element>
-		<element id="AuditEvent.entity.type.code:Query">
-			<path value="AuditEvent.entity.type.code"/>
-			<min value="1"/>
-			<fixedCode value="2"/>
-
-		</element>
-		<element id="AuditEvent.entity.role:Query">
+		<element id="AuditEvent.entity.role:Group">
 			<path value="AuditEvent.entity.role"/>
 			<short value="What role the entity played"/>
 			<definition value="Code representing the role the entity played in the event being audited."/>
@@ -740,12 +477,45 @@ For example, an activity may be initiated by one user for other users or involve
 			<type>
 				<code value="Coding"/>
 			</type>
-
+			<fixedCoding>
+				<system value= "urn:oid:2.16.756.5.30.1.127.3.10.14" />
+				<code value="GRP" />
+			</fixedCoding>
 		</element>
-		<element id="AuditEvent.entity.role.code:Query">
-			<path value="AuditEvent.entity.role.code"/>
+		<element id="AuditEvent.entity.name:Group">
+			<path value="AuditEvent.entity.name"/>
+			<short value="Group name"/>
+			<definition value="A name of the entity in the audit event."/>
+			<comment value="This field may be used in a query/report to identify audit events for a specific person.
+        For example, where multiple synonymous entity identifiers (patient number, medical record
+       number, encounter number, etc.) have been used."/>
+			<requirements value="Use only where entity can't be identified with an identifier."/>
 			<min value="1"/>
-			<fixedCode value="24"/>
+			<max value="1"/>
+			<type>
+				<code value="string"/>
+			</type>
+			<condition value="sev-1"/>
+			<mapping>
+				<identity value="rim"/>
+				<map value=".title"/>
+			</mapping>
+			<mapping>
+				<identity value="dicom"/>
+				<map value="ParticipantObjectName"/>
+			</mapping>
+			<mapping>
+				<identity value="w3c.prov"/>
+				<map value="Entity.Label"/>
+			</mapping>
+			<mapping>
+				<identity value="w5"/>
+				<map value="context"/>
+			</mapping>
+			<mapping>
+				<identity value="ch-atc"/>
+				<map value="Name of Group"/>
+			</mapping>
 		</element>
 	</differential>
 </StructureDefinition>

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -119,27 +119,10 @@
 		<element id="AuditEvent.agent">
 			<path value="AuditEvent.agent"/>
 			<short value="Notification service"/>
+			<max value="1"/>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Participants"/>
-			</mapping>
-		</element>
-		<element id="AuditEvent.agent.role">
-			<path value="AuditEvent.agent.role"/>
-			<short value="Policy Administrator (PADM)"/>
-			<min value="1"/>
-			<max value="1"/>
-			<binding>
-				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
-					<valueString value="ConditionKind"/>
-				</extension>
-				<strength value="required"/>
-				<description value="EPR Participant"/>
-				<valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"/>
-			</binding>
-			<mapping>
-				<identity value="ch-atc"/>
-				<map value="role (PADM)"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.who.identifier">

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -297,7 +297,7 @@
 			<path value="AuditEvent.entity"/>
 			<sliceName value="Group"/>
 			<short value="Group" />
-			<min value="0"/>
+			<min value="1"/>
 			<max value="1"/>
 			<mapping>
 				<identity value="ch-atc"/>
@@ -308,6 +308,7 @@
 			<path value="AuditEvent.entity.what.identifier"/>
 			<short value="Identifier for Group (OID)" />
 			<definition value="Identifier for Group (OID)"/>
+			<min value="1"/>
 			<max value="1"/>
 			<mapping>
 				<identity value="ch-atc"/>

--- a/input/resources/structuredefinition/HpdAuditEvent.xml
+++ b/input/resources/structuredefinition/HpdAuditEvent.xml
@@ -159,7 +159,7 @@
 			<slicing>
 				<discriminator>
 					<type value="value" />
-					<path value="type.code" />
+					<path value="role.code" />
 				</discriminator>
 				<rules value="open"/>
 			</slicing>
@@ -243,7 +243,7 @@
 		<element id="AuditEvent.entity:HealthcareProfessional.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
-			<fixedCode value="2"/>
+			<fixedCode value="1"/>
 		</element>
 
 		<element id="AuditEvent.entity:HealthcareProfessional.role">

--- a/input/resources/structuredefinition/PolicyAuditEvent.xml
+++ b/input/resources/structuredefinition/PolicyAuditEvent.xml
@@ -141,16 +141,12 @@
 				<map value="role (PAT, HCP, ASS, REP, GRP, PADM)"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.agent.who">
-			<path value="AuditEvent.agent.who"/>
+		<element id="AuditEvent.agent.who.identifier">
+			<path value="AuditEvent.agent.who.identifier"/>
+			<min value="1"/>
+			<max value="1"/>
 			<type>
-				<code value="Reference"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Device"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient"/>
-				<targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
+				<code value="Identifier"/>
 			</type>
 			<mapping>
 				<identity value="ch-atc"/>

--- a/input/resources/structuredefinition/PolicyAuditEvent.xml
+++ b/input/resources/structuredefinition/PolicyAuditEvent.xml
@@ -36,7 +36,7 @@
 		</coding>
 	</jurisdiction>
 	<copyright value="CC-BY-SA-4.0" />
-	<fhirVersion value="3.0.1" />
+	<fhirVersion value="4.0.1" />
 	<mapping>
 		<identity value="ch-atc" />
 		<uri value="https://www.bag.admin.ch/bag/en/home.html" />

--- a/input/resources/structuredefinition/PolicyAuditEvent.xml
+++ b/input/resources/structuredefinition/PolicyAuditEvent.xml
@@ -28,7 +28,7 @@
 			<value value="oliver.egger@ahdis.ch"/>
 		</telecom>
 	</contact>
-	<description value="This profile defines the content of the policy audit events which a community has to provide for a patients audit trail. " />
+	<description value="This profile defines the content of the policy audit events which a community has to provide for a patients audit trail." />
 	<jurisdiction>
 		<coding>
 			<system value="urn:iso:std:iso:3166"/>
@@ -42,11 +42,6 @@
 		<uri value="https://www.bag.admin.ch/bag/en/home.html" />
 		<name value="Mapping to CH ATC" />
 	</mapping>
-	<mapping>
-		<identity value="dicom"/>
-		<uri value="http://nema.org/dicom"/>
-		<name value="DICOM Tag Mapping"/>
-	</mapping>
 	<kind value="resource" />
 	<abstract value="false" />
 	<type value="AuditEvent" />
@@ -56,35 +51,17 @@
 		<element id="AuditEvent">
 			<path value="AuditEvent"/>
 			<short value="Policy Audit Trail Content Profile"/>
-			<definition value="Policy Audit Trail Content Profil"/>
-			<comment value="Based on ATNA (RFC 3881)."/>
-			<min value="0"/>
-			<max value="*"/>
 			<constraint>
 				<key value="ch-atc-pae-1"/>
 				<severity value="error"/>
 				<human value="subtype needs to be fixed to ValueSet PolicyAuditEventType"/>
-				<!--				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/PolicyAuditEventType')"/>  member of not implemented yet -->
+				<!-- <expression value="subtype.exists() and subtype.count()=1 and subtype[0].memberOf('http://fhir.ch/ig/ch-atc/ValueSet/PolicyAuditEventType')"/>  member of not implemented yet -->
 				<expression value="subtype.exists() and subtype.count()=1 and subtype[0].code.startsWith('ATC_POL')"/>
 			</constraint>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="Message"/>
-			</mapping>
 		</element>
+
 		<element id="AuditEvent.type">
 			<path value="AuditEvent.type"/>
-			<short value="Type/identifier of event"/>
-			<definition value="Identifier for a family of the event.  For example, a menu item, program, rule, policy,
-       function code, application name or URL. It identifies the performed function."/>
-			<requirements value="This identifies the performed function. For &quot;Execute&quot; Event Action Code audit
-       records, this identifies the application function performed."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="AuditEventType"/>
@@ -93,23 +70,8 @@
 				<description value="Type of event."/>
 				<valueSet value="http://hl7.org/fhir/ValueSet/audit-event-type"/>
 			</binding>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".code (type, subtype and action are pre-coordinated or sent as translations)"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventId"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Activity"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="what"/>
-			</mapping>
 		</element>
+
 		<element id="AuditEvent.subtype">
 			<path value="AuditEvent.subtype"/>
 			<slicing>
@@ -120,15 +82,6 @@
 				<rules value="open"/>
 			</slicing>
 			<min value="1"/>
-			<max value="*"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="EventTypeCode"/>
-			</mapping>
 		</element>
 		<element id="AuditEvent.subtype:PolicyAuditEventType">
 			<path value="AuditEvent.subtype"/>
@@ -136,7 +89,6 @@
 			<short value="PolicyAuditEventType" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
@@ -155,46 +107,18 @@
 			<min value="1"/>
 			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
 		</element>
+
 		<element id="AuditEvent.recorded">
 			<path value="AuditEvent.recorded"/>
-			<short value="Time when the event was recorded"/>
-			<definition value="The time when the event was recorded."/>
-			<comment value="In a distributed system, some sort of common time base (e.g. an NTP [RFC1305] server)
-       is a good implementation tactic."/>
-			<requirements value="This ties an event to a specific date and time. Security audits typically require a consistent
-       time base (e.g. UTC), to eliminate time-zone issues arising from geographical distribution."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="instant"/>
-			</type>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Event Date and Time"/>
 			</mapping>
 		</element>
+
 		<element id="AuditEvent.agent">
 			<path value="AuditEvent.agent"/>
 			<short value="Participants"/>
-			<definition value="Participants"/>
-			<comment value="Several agents may be associated (i.e. have some responsibility for an activity) with
-       an event or activity.
-
-For example, an activity may be initiated by one user for other users or involve more
-       than one user. However, only one user may be the initiator/requestor for the activity."/>
-			<requirements value="An agent can be a person, an organization, software, device, or other actors that may
-       be ascribed responsibility."/>
-			<alias value="ActiveParticipant"/>
-			<min value="1"/>
-			<max value="*"/>
-			<type>
-				<code value="BackboneElement"/>
-			</type>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ActiveParticipant"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Participants"/>
@@ -202,28 +126,16 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.role">
 			<path value="AuditEvent.agent.role"/>
-			<short value="Agent role in the event"/>
-			<definition value="The security role that the user was acting under, that come from local codes defined by
-       the access control security system (e.g. RBAC, ABAC) used in the local context."/>
-			<comment value="Should be roles relevant to the event. Should  not be an exhaustive list of roles."/>
-			<requirements value="This value ties an audited event to a user's role(s). It is an optional value that might be used to group events for analysis by user functional role categories."/>
 			<min value="1"/>
 			<max value="1"/>
-			<type>
-				<code value="CodeableConcept"/>
-			</type>
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
 				</extension>
 				<strength value="required"/>
-				<description value="EprParticipant"/>
+				<description value="EPR Participant"/>
 				<valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"/>
 			</binding>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="RoleIdCode"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="role (PAT, HCP, ASS, REP, GRP, PADM)"/>
@@ -231,13 +143,6 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.who">
 			<path value="AuditEvent.agent.who"/>
-			<short value="Identifier of who"/>
-			<definition value="Reference to who this agent is that was involved in the event."/>
-			<comment value="Where a User ID is available it will go into who.identifier."/>
-			<requirements value="This field ties an audit event to a specific resource or identifier."/>
-			<alias value="userId"/>
-			<min value="0"/>
-			<max value="1"/>
 			<type>
 				<code value="Reference"/>
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole"/>
@@ -248,30 +153,14 @@ For example, an activity may be initiated by one user for other users or involve
 				<targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson"/>
 			</type>
 			<mapping>
-				<identity value="dicom"/>
-				<map value="UserId"/>
-			</mapping>
-			<mapping>
 				<identity value="ch-atc"/>
 				<map value="applicable identifier"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.agent.name">
 			<path value="AuditEvent.agent.name"/>
-			<short value="Human-meaningful name for the agent"/>
 			<definition value="AttributeStatement/Attribute[@Name='urn:oasis:names:tc:xspa:1.0:subject:subject- id']/AttributeValue"/>
-			<requirements value="The User ID and Authorization User ID may be internal or otherwise obscure values. This
-       field assists the auditor in identifying the actual user."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="UserName"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Name"/>
@@ -279,35 +168,12 @@ For example, an activity may be initiated by one user for other users or involve
 		</element>
 		<element id="AuditEvent.agent.requestor">
 			<path value="AuditEvent.agent.requestor"/>
-			<short value="Whether user is initiator"/>
-			<definition value="Indicator that the participant is the initiator for the event being audited."/>
-			<comment value="There can only be one initiator. If the initiator is not clear, then do not choose any
-       one agent as the initiator."/>
-			<requirements value="This value is used to distinguish between requestor-users and recipient-users. For example,
-       one person may initiate a report-output to be sent to another user."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="boolean"/>
-			</type>
-
-			<mapping>
-				<identity value="rim"/>
-				<map value="If participation.typeCode was author, then true"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="UserIsRequestor"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="who"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="if participant is Initiator"/>
 			</mapping>
 		</element>
+
 		<element id="AuditEvent.entity">
 			<path value="AuditEvent.entity"/>
 			<slicing>
@@ -317,46 +183,8 @@ For example, an activity may be initiated by one user for other users or involve
 				</discriminator>
 				<rules value="open"/>
 			</slicing>
-			<short value="Data or objects used"/>
-			<definition value="Specific instances of data or objects that have been accessed."/>
-			<comment value="Required unless the values for event identification, agent identification, and audit source
-       identification are sufficient to document the entire auditable event. Because events may
-       have more than one entity, this group can be a repeating set of values."/>
-			<requirements value="The event may have other entities involved."/>
-			<alias value="ParticipantObject"/>
-			<min value="0"/>
-			<max value="*"/>
-			<type>
-				<code value="BackboneElement"/>
-			</type>
-			<constraint>
-				<key value="sev-1"/>
-				<severity value="error"/>
-				<human value="Either a name or a query (NOT both)"/>
-				<expression value="name.empty() or query.empty()"/>
-				<xpath value="not(exists(f:name)) or not(exists(f:query))"/>
-			</constraint>
-			<mapping>
-				<identity value="w5"/>
-				<map value="FiveWs.what[x]"/>
-			</mapping>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".outboundRelationship[typeCode=SUBJ].target  or .participation[typeCode=SBJ].role"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectIdentification"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Entity"/>
-			</mapping>
-			<mapping>
-				<identity value="fhirprovenance"/>
-				<map value="Provenance.target, Provenance.entity"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Patient -->
 		<element id="AuditEvent.entity:Patient">
 			<path value="AuditEvent.entity"/>
@@ -364,77 +192,48 @@ For example, an activity may be initiated by one user for other users or involve
 			<short value="Patient" />
 			<min value="1"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Patient"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Patient">
+		<element id="AuditEvent.entity:Patient.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
 			<short value="Patient Id (EPR-SPID)" />
-			<definition value="Patient Id (EPR-SPID)"/>
-			<comment value="."/>
 			<min value="1"/>
 			<max value="1"/>
 			<type>
 				<code value="Identifier"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectID and ParticipantObjectIDTypeCode"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="EPR-SPID"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier.system:Patient">
+		<element id="AuditEvent.entity:Patient.what.identifier.system">
 			<path value="AuditEvent.entity.what.identifier.system"/>
 			<min value="1"/>
 			<fixedUri value="urn:oid:2.16.756.5.30.1.127.3.10.3"/>
 		</element>
-		<element id="AuditEvent.entity.type:Patient">
+		<element id="AuditEvent.entity:Patient.type">
 			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.type.code:Patient">
+		<element id="AuditEvent.entity:Patient.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
 			<fixedCode value="1"/>
-
 		</element>
-		<element id="AuditEvent.entity.role:Patient">
+		<element id="AuditEvent.entity:Patient.role">
 			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.role.code:Patient">
+		<element id="AuditEvent.entity:Patient.role.code">
 			<path value="AuditEvent.entity.role.code"/>
 			<min value="1"/>
 			<fixedCode value="1"/>
-
 		</element>
+
 		<!-- Slice  Resource -->
 		<element id="AuditEvent.entity:Resource">
 			<path value="AuditEvent.entity"/>
@@ -442,65 +241,42 @@ For example, an activity may be initiated by one user for other users or involve
 			<short value="Resource (HCP, Group, Representative of Patient)" />
 			<min value="0"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Resource"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.what.identifier:Resource">
+		<element id="AuditEvent.entity:Resource.what.identifier">
 			<path value="AuditEvent.entity.what.identifier"/>
-			<short value="Identifier. HCP (GLN), Group (OID)" />
-			<definition value="Identifier. HCP (GLN), Group (OID)"/>
+			<short value="Identifier: HCP (GLN), Group (OID)" />
 			<min value="0"/>
 			<max value="1"/>
 			<type>
 				<code value="Identifier"/>
 			</type>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="identifier: GLN for HCP, OID for Group"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.type:Resource">
+		<element id="AuditEvent.entity:Resource.type">
 			<path value="AuditEvent.entity.type"/>
-			<short value="Type of entity involved"/>
-			<definition value="The type of the object that was involved in this audit event."/>
-			<comment value="This value is distinct from the user's role or any user relationship to the entity."/>
-			<requirements value="To describe the object being acted upon. In addition to queries on the subject of the
-       action in an auditable event, it is also important to be able to query on the object type
-       for the action."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 		</element>
-		<element id="AuditEvent.entity.type.code:Resource">
+		<element id="AuditEvent.entity:Resource.type.code">
 			<path value="AuditEvent.entity.type.code"/>
 			<min value="1"/>
 			<fixedCode value="2"/>
 		</element>
-		<element id="AuditEvent.entity.role:Resource">
+		<element id="AuditEvent.entity:Resource.role">
 			<path value="AuditEvent.entity.role"/>
-			<short value="What role the entity played"/>
-			<definition value="Code representing the role the entity played in the event being audited."/>
-			<requirements value="For some detailed audit analysis it may be necessary to indicate a more granular type
-       of entity, based on the application role it serves."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Coding"/>
-			</type>
-
 			<binding>
 				<extension url="http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName">
 					<valueString value="ConditionKind"/>
 				</extension>
 				<strength value="required"/>
-				<description value="EprParticipant"/>
+				<description value="EPR Participant"/>
 				<valueSet value="http://fhir.ch/ig/ch-atc/ValueSet/EprParticipant"/>
 			</binding>
 			<mapping>
@@ -508,42 +284,15 @@ For example, an activity may be initiated by one user for other users or involve
 				<map value="role (HCP, REP, GRP)"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.name:Resource">
+		<element id="AuditEvent.entity:Resource.name">
 			<path value="AuditEvent.entity.name"/>
-			<short value="Descriptor for entity"/>
-			<definition value="A name of the entity in the audit event."/>
-			<comment value="This field may be used in a query/report to identify audit events for a specific person.
-        For example, where multiple synonymous entity identifiers (patient number, medical record
-       number, encounter number, etc.) have been used."/>
-			<requirements value="Use only where entity can't be identified with an identifier."/>
 			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
-			<condition value="sev-1"/>
-			<mapping>
-				<identity value="rim"/>
-				<map value=".title"/>
-			</mapping>
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectName"/>
-			</mapping>
-			<mapping>
-				<identity value="w3c.prov"/>
-				<map value="Entity.Label"/>
-			</mapping>
-			<mapping>
-				<identity value="w5"/>
-				<map value="context"/>
-			</mapping>
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="Name of HCP, Group or Representative of Patient"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail:Resource">
+		<element id="AuditEvent.entity:Resource.detail">
 			<path value="AuditEvent.entity.detail"/>
 			<slicing>
 				<discriminator>
@@ -552,138 +301,83 @@ For example, an activity may be initiated by one user for other users or involve
 				</discriminator>
 				<rules value="open"/>
 			</slicing>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Resource Detail: AccessLevel  -->
-		<element id="AuditEvent.entity.detail:Resource:AccessLevel">
+		<element id="AuditEvent.entity:Resource.detail:AccessLevel">
 			<path value="AuditEvent.entity.detail"/>
 			<sliceName value="AccessLevel"/>
 			<short value="AccessLevel if subtype is Create or Update" />
 			<definition value="The type of extra detail provided in the value."/>
-			<min value="0"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="AccessLevel"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail.type:Resource:AccessLevel">
+		<element id="AuditEvent.entity:Resource.detail.type:AccessLevel">
 			<path value="AuditEvent.entity.detail.type"/>
-			<short value="The type of extra detail provided in the value."/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
+			<short value="The type of extra detail provided in the value"/>
 			<fixedString value="AccessLevel"/>
-
 		</element>
-		<element id="AuditEvent.entity.detail.value:Resource:AccessLevel">
+		<element id="AuditEvent.entity:Resource.detail.value:AccessLevel">
 			<path value="AuditEvent.entity.detail.value"/>
-			<short value="one of urn:e-health-suisse:2015:policies:access-level: normal,restricted,delegation-and-restricted,delegation-and-normal or full"/>
+			<short value="one of urn:e-health-suisse:2015:policies:access-level: normal, restricted, delegation-and-restricted, delegation-and-normal or full"/>
 			<definition value="The details, base64 encoded. Used to carry bulk information."/>
 			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
 			<type>
 				<code value="base64Binary"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Document Detail: AccessLimitedToDate  -->
-		<element id="AuditEvent.entity.detail:Resource:AccessLimitedToDate">
+		<element id="AuditEvent.entity:Resource.detail:AccessLimitedToDate">
 			<path value="AuditEvent.entity.detail"/>
 			<sliceName value="AccessLimitedToDate"/>
 			<short value="AccessLimitedToDate if subtype is Create or Update" />
-			<min value="0"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="AccessLimitedToDate"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail.type:Resource:AccessLimitedToDate">
+		<element id="AuditEvent.entity:Resource.detail.type:AccessLimitedToDate">
 			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
 			<fixedString value="AccessLimitedToDate"/>
-
 		</element>
-		<element id="AuditEvent.entity.detail.value:Resource:AccessLimitedToDate">
+		<element id="AuditEvent.entity:Resource.detail.value:AccessLimitedToDate">
 			<path value="AuditEvent.entity.detail.value"/>
-			<short value="date in Property value"/>
+			<short value="Date in property value"/>
 			<definition value="The details, base64 encoded. Used to carry bulk information."/>
 			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
 			<type>
 				<code value="base64Binary"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
 		</element>
+
 		<!-- Slice Resource: Detail: ProvideLevel  -->
-		<element id="AuditEvent.entity.detail:Resource:ProvideLevel">
+		<element id="AuditEvent.entity:Resource.detail:ProvideLevel">
 			<path value="AuditEvent.entity.detail"/>
 			<sliceName value="ProvideLevel"/>
 			<short value="ProvideLevel if subtype is ATC_POL_DEF_CONFLEVEL" />
-			<min value="0"/>
 			<max value="1"/>
-
 			<mapping>
 				<identity value="ch-atc"/>
 				<map value="ProvideLevel"/>
 			</mapping>
 		</element>
-		<element id="AuditEvent.entity.detail.type:Resource:ProvideLevel">
+		<element id="AuditEvent.entity:Resource.detail.type:ProvideLevel">
 			<path value="AuditEvent.entity.detail.type"/>
-			<short value="Name of the property"/>
-			<definition value="The type of extra detail provided in the value."/>
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="string"/>
-			</type>
 			<fixedString value="ProvideLevel"/>
-
 		</element>
 		<element id="AuditEvent.entity.detail.value:ProvideLevel">
 			<path value="AuditEvent.entity.detail.value"/>
 			<short value="one of urn:e-health-suisse:2015:policies:provide-level: normal, restricted or secret"/>
 			<definition value="The details, base64 encoded. Used to carry bulk information."/>
 			<comment value="The value is base64 encoded to enable various encodings or binary content."/>
-			<requirements value="Should not duplicate the entity value unless absolutely necessary."/>
-			<min value="1"/>
-			<max value="1"/>
 			<type>
 				<code value="base64Binary"/>
 			</type>
-
-			<mapping>
-				<identity value="dicom"/>
-				<map value="ParticipantObjectDetail.value"/>
-			</mapping>
 		</element>
 	</differential>
 </StructureDefinition>

--- a/input/resources/valueset/DocumentAuditEventType.xml
+++ b/input/resources/valueset/DocumentAuditEventType.xml
@@ -44,6 +44,7 @@
             </concept>
             <concept>
                 <code value="ATC_DOC_SEARCH" />
+                <display value="Document search" />
             </concept>
         </include>
     </compose>

--- a/input/resources/valueset/DocumentAuditEventType.xml
+++ b/input/resources/valueset/DocumentAuditEventType.xml
@@ -43,7 +43,7 @@
                 <code value="ATC_DOC_DELETE" />
             </concept>
             <concept>
-                <code value="ATC_DOC_META_QUERY" />
+                <code value="ATC_DOC_SEARCH" />
             </concept>
         </include>
     </compose>

--- a/input/resources/valueset/HpdAuditEventType.xml
+++ b/input/resources/valueset/HpdAuditEventType.xml
@@ -1,15 +1,15 @@
 <ValueSet xmlns="http://hl7.org/fhir">
-    <id value="DocumentAuditEventType"/>
+    <id value="HpdAuditEventType"/>
     <meta>
         <profile value="http://hl7.org/fhir/StructureDefinition/shareablevalueset"/>
     </meta>
-    <url value="http://fhir.ch/ig/ch-atc/ValueSet/DocumentAuditEventType"/>
+    <url value="http://fhir.ch/ig/ch-atc/ValueSet/HpdAuditEventType"/>
     <version value="1.2.0"/>
-    <name value="DocumentAuditEventType"/>
-    <title value="DocumentAuditEventType"/>
+    <name value="HpdAuditEventType"/>
+    <title value="HpdAuditEventType"/>
     <status value="draft"/>
     <experimental value="false"/>
-    <date value="2018-05-28" />
+    <date value="2022-06-29" />
     <publisher value="eHealth Suisse"/>
     <contact>
         <name value="eHealth Suisse"/>
@@ -31,19 +31,7 @@
         <include>
             <system value="urn:oid:2.16.756.5.30.1.127.3.10.7"/>
             <concept>
-                <code value="ATC_DOC_CREATE" />
-            </concept>
-            <concept>
-                <code value="ATC_DOC_READ" />
-            </concept>
-            <concept>
-                <code value="ATC_DOC_UPDATE" />
-            </concept>
-            <concept>
-                <code value="ATC_DOC_DELETE" />
-            </concept>
-            <concept>
-                <code value="ATC_DOC_META_QUERY" />
+                <code value="ATC_HPD_GROUP_ENTRY_NOTIFY" />
             </concept>
         </include>
     </compose>


### PR DESCRIPTION
Updated IHE RESTFul ATNA a nd  IUA versions to:
- https://www.ihe.net/uploadedFiles/Documents/ITI/IHE_ITI_Suppl_RESTful-ATNA_Rev3-3_TI_2021-07-02.pdf 
- https://profiles.ihe.net/ITI/IUA/index.html Internet User Authorization (IUA) (Date: June 17, 2022, Revision 2.2)

Changed invalid EPR Document Type in examples, see https://github.com/ehealthsuisse/ch-atc/issues/1

Added 2 new AuditEvent Types;
- Document Metadata query
- Notification of patient for entry of healthcare professional into group
