### PR TITLE
use artifcat identifier extension #6

### DIFF
--- a/input/examples/bundle/ch-atc-iti-81-response-sample.xml
+++ b/input/examples/bundle/ch-atc-iti-81-response-sample.xml
@@ -339,7 +339,7 @@
                     <severity value="warning"/>
                     <code value="incomplete"/>
                     <details>
-                      <extension url="https://profiles.ihe.net/ITI/BALP/StructureDefinition/ihe-otherId">
+                      <extension url="http://hl7.org/fhir/StructureDefinition/artifact-identifier">
                         <valueIdentifier>
                           <type>
                             <coding>


### PR DESCRIPTION
as suggested by john we will use http://hl7.org/fhir/StructureDefinition/artifact-identifier instead of the not used anymore otherId extension