### PR TITLE
Correct system for XDSDocumentEntry.uniqueId

### DIFF
--- a/input/examples/auditevent/atc-doc-create-rep-pat.xml
+++ b/input/examples/auditevent/atc-doc-create-rep-pat.xml
@@ -88,7 +88,7 @@
          <identifier>
             <type>
                <coding>
-                  <system value="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab"></system>
+                  <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"></system>
                   <code value="IHE XDS Metadata"></code>
                   <display value="XDSDocumentEntry.uniqueId"></display>
                </coding>

--- a/input/examples/auditevent/atc-doc-read-ass-hpc.xml
+++ b/input/examples/auditevent/atc-doc-read-ass-hpc.xml
@@ -105,7 +105,7 @@
          <identifier>
             <type>
                <coding>
-                  <system value="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab"></system>
+                  <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"></system>
                   <code value="IHE XDS Metadata"></code>
                   <display value="XDSDocumentEntry.uniqueId"></display>
                </coding>

--- a/input/examples/bundle/ch-atc-iti-81-response-sample.xml
+++ b/input/examples/bundle/ch-atc-iti-81-response-sample.xml
@@ -12,7 +12,7 @@
     <url value="/r4/*/AuditEvent"/>
   </link>
   <entry>
-    <fullUrl value="/r4/*/AuditEvent/1"/>
+    <fullUrl value="http://fhir.ch/r4/AuditEvent/1"/>
     <resource>
       <AuditEvent xmlns="http://hl7.org/fhir">
         <id value="1"/>
@@ -108,7 +108,7 @@
             <identifier>
               <type>
                 <coding>
-                  <system value="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab"/>
+                  <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"/>
                   <code value="IHE XDS Metadata"/>
                   <display value="XDSDocumentEntry.uniqueId"/>
                 </coding>
@@ -155,7 +155,7 @@
     </search>
   </entry>
   <entry>
-    <fullUrl value="/r4/*/AuditEvent/2"/>
+    <fullUrl value="http://fhir.ch/r4/AuditEvent/2"/>
     <resource>
       <AuditEvent xmlns="http://hl7.org/fhir">
         <id value="2"/>
@@ -229,7 +229,7 @@
     </search>
   </entry>
   <entry>
-    <fullUrl value="/r4/*/AuditEvent/3"/>
+    <fullUrl value="http://fhir.ch/r4/AuditEvent/3"/>
     <resource>
       <AuditEvent xmlns="http://hl7.org/fhir">
         <id value="3"/>

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -1,7 +1,8 @@
 == Suppressed Messages ==
 
 # Represents the XDSDocumentEntry.uniqueId
-Code System URI 'urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab' is unknown so the code cannot be validated
+Code System URI 'urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier' could not be found so the code cannot be validated
+Code System URI 'urn:ihe:iti:xca:2010' could not be found so the code cannot be validated
 
 # Build errors
 The link 'StructureDefinition-DocumentAuditEvent-definitions.html#AuditEvent.entity:Document.detail:repositoryUniqueId.value' for "value" cannot be resolved (valid targets: 261 targets)

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,21 +1,21 @@
 
 All significant changes to this FHIR implementation guide will be documented on this page.   
 
-### v3.2.0 
+### v3.2.0-ci-build 
 
 The implementation guide was under an informative ballot by HL7 Switzerland until September 30th, 2023. The following comments/issues have been raised and fixed:
 
 #### Added
-* Example for partial result in CH:ATC Query
-
-#### Open
-* Overview of transactions/usecases [#12](https://github.com/ehealthsuisse/ch-atc/issues/12) 
-* Various comments [#7](https://github.com/ehealthsuisse/ch-atc/issues/7) 
+* [Example](Bundle-ch-atc-iti-81-response-sample.xml.html) for partial result in CH:ATC Query [#6](https://github.com/ehealthsuisse/ch-atc/issues/6)
 
 #### Fixed
+* Correct system for XDSDocumentEntry.uniqueId [#15](https://github.com/ehealthsuisse/ch-atc/issues/15) (raised in various comments [#7](https://github.com/ehealthsuisse/ch-atc/issues/7))
 * Missing Feedback link, footer 3.2.0-ballot [#10](https://github.com/ehealthsuisse/ch-atc/issues/10), [#5](https://github.com/ehealthsuisse/ch-atc/issues/5)
 * History page and naming, status [#9](https://github.com/ehealthsuisse/ch-atc/issues/9), [#11](https://github.com/ehealthsuisse/ch-atc/issues/11)  
 * Partial Results [#6](https://github.com/ehealthsuisse/ch-atc/issues/6) 
+
+#### Open
+* Overview of transactions/usecases [#12](https://github.com/ehealthsuisse/ch-atc/issues/12) 
 
 ### v3.2.0-ballot (2023-06-30)
 

--- a/input/resources/valueset/DocumentAuditEventType.xml
+++ b/input/resources/valueset/DocumentAuditEventType.xml
@@ -44,7 +44,6 @@
             </concept>
             <concept>
                 <code value="ATC_DOC_SEARCH" />
-                <display value="Document search" />
             </concept>
         </include>
     </compose>


### PR DESCRIPTION
Correct system for XDSDocumentEntry.uniqueId [#15](https://github.com/ehealthsuisse/ch-atc/issues/15) (raised in various comments [#7](https://github.com/ehealthsuisse/ch-atc/issues/7))