### PR TITLE
#38 CP EPDBEP-244

### DIFF
--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -118,6 +118,14 @@
     </resource>
     <resource>
       <reference>
+        <reference value="StructureDefinition/ch-atc-uniqueid-identifier" />
+      </reference>
+      <name value="Identifier for XDSDocumentEntry.uniqueId" />
+      <description value="Identifier for XDSDocumentEntry.uniqueId" />
+      <exampleBoolean value="false" />
+    </resource>
+    <resource>
+      <reference>
         <reference value="ValueSet/EprParticipant" />
       </reference>
       <name value="EprParticipant" />

--- a/input/examples/auditevent/atc-doc-create-rep-pat.xml
+++ b/input/examples/auditevent/atc-doc-create-rep-pat.xml
@@ -108,12 +108,10 @@
             <type>
                <coding>
                   <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"></system>
-                  <code value="IHE XDS Metadata"></code>
-                  <display value="XDSDocumentEntry.uniqueId"></display>
+                  <code value="XDSDocumentEntry.uniqueId"></code>
                </coding>
             </type>
-            <system value="urn:ietf:rfc:3986"></system>
-            <value value="urn:oid:1.2.3.4.5"></value>
+            <value value="1.2.3.4.5"></value>
          </identifier>
       </what>
       <type>

--- a/input/examples/auditevent/atc-doc-create-rep-pat.xml
+++ b/input/examples/auditevent/atc-doc-create-rep-pat.xml
@@ -105,12 +105,7 @@
    <entity>
       <what>
          <identifier>
-            <type>
-               <coding>
-                  <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"></system>
-                  <code value="XDSDocumentEntry.uniqueId"></code>
-               </coding>
-            </type>
+            <system value="urn:ihe:iti:xds:2013:uniqueId" />
             <value value="1.2.3.4.5"></value>
          </identifier>
       </what>

--- a/input/examples/auditevent/atc-doc-read-ass-hpc.xml
+++ b/input/examples/auditevent/atc-doc-read-ass-hpc.xml
@@ -124,12 +124,10 @@
             <type>
                <coding>
                   <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"></system>
-                  <code value="IHE XDS Metadata"></code>
-                  <display value="XDSDocumentEntry.uniqueId"></display>
+                  <code value="XDSDocumentEntry.uniqueId"></code>
                </coding>
             </type>
-            <system value="urn:ietf:rfc:3986"></system>
-            <value value="urn:oid:1.2.3.4.5"></value>
+            <value value="1.2.3.4.5"></value>
          </identifier>
       </what>
       <type>

--- a/input/examples/auditevent/atc-doc-read-ass-hpc.xml
+++ b/input/examples/auditevent/atc-doc-read-ass-hpc.xml
@@ -121,12 +121,7 @@
    <entity>
       <what>
          <identifier>
-            <type>
-               <coding>
-                  <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"></system>
-                  <code value="XDSDocumentEntry.uniqueId"></code>
-               </coding>
-            </type>
+            <system value="urn:ihe:iti:xds:2013:uniqueId" />
             <value value="1.2.3.4.5"></value>
          </identifier>
       </what>

--- a/input/examples/bundle/ch-atc-iti-81-response-sample.xml
+++ b/input/examples/bundle/ch-atc-iti-81-response-sample.xml
@@ -109,12 +109,10 @@
               <type>
                 <coding>
                   <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"/>
-                  <code value="IHE XDS Metadata"/>
-                  <display value="XDSDocumentEntry.uniqueId"/>
+                  <code value="XDSDocumentEntry.uniqueId"/>
                 </coding>
               </type>
-              <system value="urn:ietf:rfc:3986"/>
-              <value value="urn:oid:1.2.3.4.5"/>
+              <value value="1.2.3.4.5"/>
             </identifier>
           </what>
           <type>

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,6 +1,11 @@
 
 All significant changes to this FHIR implementation guide will be documented on this page.   
 
+### v3.3.0
+
+* [#38](https://github.com/ehealthsuisse/ch-atc/issues/38) CP 'EPDBEP-244' XDSDocumentEntry.uniqueId precision
+
+
 ### v3.3.0-ballot (2024-05-17)
 
 #### Added

--- a/input/resources/structuredefinition/DocumentAuditEvent.xml
+++ b/input/resources/structuredefinition/DocumentAuditEvent.xml
@@ -234,16 +234,17 @@
 			</mapping>
 		</element>
 		<element id="AuditEvent.entity:Document.what.identifier">
-			<path value="AuditEvent.entity.what.identifier"/>
+            <path value="AuditEvent.entity.what.identifier"/>
 			<short value="XDSDocumentEntry.uniqueId" />
-			<min value="1"/>
-			<max value="1"/>
-			<type>
-				<code value="Identifier"/>
-			</type>
+            <min value="1"/>
+            <max value="1"/>
+            <type>
+                <code value="Identifier"/>
+				<profile value="http://fhir.ch/ig/ch-atc/StructureDefinition/ch-atc-uniqueid-identifier" />
+            </type>
 			<mapping>
 				<identity value="ch-atc"/>
-				<map value="uniqueId"/>
+				<map value="XDSDocumentEntry.uniqueId"/>
 			</mapping>
 		</element>
 		<element id="AuditEvent.entity:Document.type">

--- a/input/resources/structuredefinition/ch-atc-uniqueid-identifier.xml
+++ b/input/resources/structuredefinition/ch-atc-uniqueid-identifier.xml
@@ -13,19 +13,10 @@
     <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier"/>
     <derivation value="constraint"/>
     <differential>
-        <element id="Identifier.type">
-            <path value="Identifier.type"/>
-            <min value="1"/>
-            <patternCodeableConcept>
-                <coding>
-                    <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"/>
-                    <code value="XDSDocumentEntry.uniqueId"/>
-                </coding>
-            </patternCodeableConcept>
-        </element>
         <element id="Identifier.system">
             <path value="Identifier.system"/>
-            <max value="0"/>
+            <min value="1"/>
+            <fixedUri value="urn:ihe:iti:xds:2013:uniqueId"/>
         </element>
         <element id="Identifier.value">
             <path value="Identifier.value"/>

--- a/input/resources/structuredefinition/ch-atc-uniqueid-identifier.xml
+++ b/input/resources/structuredefinition/ch-atc-uniqueid-identifier.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StructureDefinition xmlns="http://hl7.org/fhir">
+    <id value="ch-atc-uniqueid-identifier"/>
+    <url value="http://fhir.ch/ig/ch-atc/StructureDefinition/ch-atc-uniqueid-identifier"/>
+    <name value="UniqueidIdentifier"/>
+    <title value="Identifier for XDSDocumentEntry.uniqueId"/>
+    <status value="active"/>
+    <description value="Identifier holding the XDSDocumentEntry.uniqueId"/>
+    <fhirVersion value="4.0.1"/>
+    <kind value="complex-type"/>
+    <abstract value="false"/>
+    <type value="Identifier"/>
+    <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Identifier"/>
+    <derivation value="constraint"/>
+    <differential>
+        <element id="Identifier.type">
+            <path value="Identifier.type"/>
+            <min value="1"/>
+            <patternCodeableConcept>
+                <coding>
+                    <system value="urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier"/>
+                    <code value="XDSDocumentEntry.uniqueId"/>
+                </coding>
+            </patternCodeableConcept>
+        </element>
+        <element id="Identifier.system">
+            <path value="Identifier.system"/>
+            <max value="0"/>
+        </element>
+        <element id="Identifier.value">
+            <path value="Identifier.value"/>
+            <min value="1"/>
+            <example>
+                <label value="General"/>
+                <valueString value="2.999.1.2.3.4"/>
+              </example>
+            <mapping>
+				<identity value="ch-atc"/>
+				<map value="XDSDocumentEntry.uniqueId"/>
+			</mapping>
+        </element>
+    </differential>
+</StructureDefinition>


### PR DESCRIPTION
1. remove urn:oid prefix according to CP 'EPDBEP-244' in value, and remove synstem in the examples 
2. system should not be provided, define identifier by type with

```json
      "identifier" : {
          "type" : {
            "coding" : [
              {
                "system" : "urn:oasis:names:tc:ebxml-regrep:ObjectType:RegistryObject:ExternalIdentifier",
                "code" : "XDSDocumentEntry.uniqueId"
              }
            ]
          },
          "value" : "1.2.3.4.5"
        }
```

need to adapt CP code would be fixed to XDSDocumentEntry.uniqueId instead of IHE XDS Metadata