### PR TITLE
Update IG dependencies

### DIFF
--- a/input/ch.fhir.ig.ch-atc.xml
+++ b/input/ch.fhir.ig.ch-atc.xml
@@ -51,12 +51,12 @@
   <dependsOn id="cheprfhir">
     <uri value="http://fhir.ch/ig/ch-epr-fhir/ImplementationGuide/ch.fhir.ig.ch-epr-fhir"/>
     <packageId value="ch.fhir.ig.ch-epr-fhir"/>
-    <version value="4.0.1-ballot"/>
+    <version value="4.0.1-ballot-2"/>
   </dependsOn>
   <dependsOn id="hl7terminology">
     <uri value="http://terminology.hl7.org/ImplementationGuide/hl7.terminology"/>
     <packageId value="hl7.terminology"/>
-    <version value="5.5.0"/>
+    <version value="6.1.0"/>
   </dependsOn>
   <dependsOn id="iheitibalp">
     <uri value="https://profiles.ihe.net/ITI/BALP/ImplementationGuide/ihe.iti.balp"/>

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -10,6 +10,7 @@ All significant changes to this FHIR implementation guide will be documented on 
 * Remove user from Additional ATNA Search Parameters [#40](https://github.com/ehealthsuisse/ch-atc/issues/40)
 * Add a CapabilityStatement for the Patient Audit Record Repository [#47](https://github.com/ehealthsuisse/ch-atc/issues/47) 
 * Align min cardinalities in the ChAtcIti81Response profile [#48](https://github.com/ehealthsuisse/ch-atc/issues/48)
+* Update the IG dependencies to the current published versions (HL7 Terminology 6.1.0, CH EPR FHIR 4.0.1-ballot-2)
 
 ### v3.3.0-ballot (2024-05-17)
 


### PR DESCRIPTION
Update the IG dependencies to the current published versions (HL7 Terminology 6.1.0, CH EPR FHIR 4.0.1-ballot-2)